### PR TITLE
Improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,7 @@ script:
   - pytest -s --cov=guillotina_amqp -s --tb=native -v --cov-report term-missing --cov-append guillotina_amqp
 after_success:
   - codecov
+services:
+  - redis-server
+  - rabbitmq
+  - docker

--- a/guillotina_amqp/__init__.py
+++ b/guillotina_amqp/__init__.py
@@ -15,7 +15,7 @@ app_settings = {
         "heartbeat": 800,
         "exchange": "",
         "queue": "guillotina",
-        "persistent_manager": "dummy"
+        "persistent_manager": "memory"
     },
     'commands': {
         "amqp-worker": "guillotina_amqp.commands.worker.WorkerCommand"

--- a/guillotina_amqp/amqp.py
+++ b/guillotina_amqp/amqp.py
@@ -45,7 +45,7 @@ async def handle_connection_closed(name, protocol):
             return
         # we just remove so next time get_connection is retrieved, a new
         # connection is retrieved.
-        logger.warn('Disconnect detected with rabbitmq connection, forcing reconnect')
+        logger.warning('Disconnect detected with rabbitmq connection, forcing reconnect')
         await remove_connection(name)
     except Exception:
         logger.error('Error waiting for connection to close', exc_info=True)

--- a/guillotina_amqp/api.py
+++ b/guillotina_amqp/api.py
@@ -1,42 +1,70 @@
 from guillotina import configure
-from .state import get_state_manager, TaskState
-from .exceptions import TaskNotFoundException
+from aiohttp.web_exceptions import HTTPPreconditionFailed
+# TODO: change to guillotina.response
+# from guillotina.response import HTTPPreconditionFailed
+from .state import get_state_manager
 
 
 @configure.service(method='GET', name='@amqp-tasks',
-                   permission='guillotina.AccessContent')
+                   permission='guillotina.AccessContent',
+                   summary='Returns the list of running tasks')
 async def list_tasks(context, request):
     mngr = get_state_manager()
-
     ret = []
     async for el in mngr.list():
         ret.append(el)
     return ret
 
 
-@configure.service(method='GET', name='@amqp-info',
-                   permission='guillotina.AccessContent')
+@configure.service(
+    method='GET', name='@amqp-info',
+    permission='guillotina.AccessContent',
+    summary='Shows the info of a given task id',
+    parameters=[{
+        "name": "task_id",
+        "in": "query",
+        "required": True,
+        "type": "string",
+    }])
 async def info_task(context, request):
     mngr = get_state_manager()
+
     task_id = request.rel_url.query.get('task_id')
     if not task_id:
-        raise TaskNotFinishedException()
+        raise HTTPPreconditionFailed(content={
+            'reason': 'Missing task_id'
+        })
 
     return await mngr.get(task_id)
 
 
-@configure.service(method='DELETE', name='@amqp-cancel',
-                   permission='guillotina.AccessContent')
+@configure.service(
+    method='DELETE', name='@amqp-cancel',
+    permission='guillotina.AccessContent',
+    summary='Cancel a specific task by id',
+    parameters=[{
+        "name": "task_id",
+        "in": "query",
+        "required": True,
+        "type": "string",
+    }])
 async def cancel_task(context, request):
     mngr = get_state_manager()
+
     task_id = request.rel_url.query.get('task_id')
+    if not task_id:
+        raise HTTPPreconditionFailed(content={
+            'reason': 'Missing task_id'
+        })
 
-    task = TaskState(task_id)
-    return await task.cancel()
+    return await mngr.cancel(task_id)
 
 
+
+"""
 @configure.service(method='GET', name='@amqp-stats',
                    permission='guillotina.AccessContent')
 async def task_stats(context, request):
     mngr = get_state_manager()
     return await mngr.list()
+"""

--- a/guillotina_amqp/api.py
+++ b/guillotina_amqp/api.py
@@ -72,9 +72,28 @@ async def cancel_task(context, request):
         #     'reason': 'Missing task_id'
         # })
 
-    success = await mngr.cancel(task_id)
+    if await mngr.is_canceled(task_id):
+        return {
+            'ok': True,
+            'info': 'already canceled'
+        }
+
+    if not await mngr.exists(task_id):
+        raise HTTPNotFound(reason='Task unexisting task')
+        # TODO: replace for below to upgrade to g4
+        # raise HTTPNotFound(content={
+        #     'reason': 'Task not found'
+        # })
+
+    if await mngr.cancel(task_id):
+        return {
+            'ok': True,
+            'info': 'task canceled'
+        }
+
     return {
-        'ok': success
+        'ok': False,
+        'info': 'could not cancel task'
     }
 
 

--- a/guillotina_amqp/api.py
+++ b/guillotina_amqp/api.py
@@ -1,7 +1,10 @@
 from guillotina import configure
+
 from aiohttp.web_exceptions import HTTPPreconditionFailed
-# TODO: change to guillotina.response
+from aiohttp.web_exceptions import HTTPNotFound
+# TODO: change to guillotina.response to upgrate to g4
 # from guillotina.response import HTTPPreconditionFailed
+
 from .state import get_state_manager
 
 
@@ -31,9 +34,19 @@ async def info_task(context, request):
 
     task_id = request.rel_url.query.get('task_id')
     if not task_id:
-        raise HTTPPreconditionFailed(content={
-            'reason': 'Missing task_id'
-        })
+        raise HTTPPreconditionFailed(reason='Missing task_id')
+        # TODO: replace for below to upgrade to g4
+        # raise HTTPPreconditionFailed(content={
+        #     'reason': 'Missing task_id'
+        # })
+
+    data = await mngr.get(task_id)
+    if not data:
+        raise HTTPNotFound(reason='Task not found')
+        # TODO: replace for below to upgrade to g4
+        # raise HTTPNotFound(content={
+        #     'reason': 'Task not found'
+        # })
 
     return await mngr.get(task_id)
 
@@ -53,11 +66,16 @@ async def cancel_task(context, request):
 
     task_id = request.rel_url.query.get('task_id')
     if not task_id:
-        raise HTTPPreconditionFailed(content={
-            'reason': 'Missing task_id'
-        })
+        raise HTTPPreconditionFailed(reason='Missing task_id')
+        # TODO: replace for below to upgrade to g4
+        # raise HTTPPreconditionFailed(content={
+        #     'reason': 'Missing task_id'
+        # })
 
-    return await mngr.cancel(task_id)
+    success = await mngr.cancel(task_id)
+    return {
+        'ok': success
+    }
 
 
 

--- a/guillotina_amqp/api.py
+++ b/guillotina_amqp/api.py
@@ -97,7 +97,6 @@ async def cancel_task(context, request):
     }
 
 
-
 """
 @configure.service(method='GET', name='@amqp-stats',
                    permission='guillotina.AccessContent')

--- a/guillotina_amqp/api.py
+++ b/guillotina_amqp/api.py
@@ -1,9 +1,7 @@
 from guillotina import configure
 
-from aiohttp.web_exceptions import HTTPPreconditionFailed
-from aiohttp.web_exceptions import HTTPNotFound
-# TODO: change to guillotina.response to upgrate to g4
-# from guillotina.response import HTTPPreconditionFailed
+from guillotina.response import HTTPPreconditionFailed
+from guillotina.response import HTTPNotFound
 
 from .state import get_state_manager
 
@@ -34,19 +32,15 @@ async def info_task(context, request):
 
     task_id = request.rel_url.query.get('task_id')
     if not task_id:
-        raise HTTPPreconditionFailed(reason='Missing task_id')
-        # TODO: replace for below to upgrade to g4
-        # raise HTTPPreconditionFailed(content={
-        #     'reason': 'Missing task_id'
-        # })
+        raise HTTPPreconditionFailed(content={
+            'reason': 'Missing task_id'
+        })
 
     data = await mngr.get(task_id)
     if not data:
-        raise HTTPNotFound(reason='Task not found')
-        # TODO: replace for below to upgrade to g4
-        # raise HTTPNotFound(content={
-        #     'reason': 'Task not found'
-        # })
+        raise HTTPNotFound(content={
+            'reason': 'Task not found'
+        })
 
     return await mngr.get(task_id)
 
@@ -66,11 +60,9 @@ async def cancel_task(context, request):
 
     task_id = request.rel_url.query.get('task_id')
     if not task_id:
-        raise HTTPPreconditionFailed(reason='Missing task_id')
-        # TODO: replace for below to upgrade to g4
-        # raise HTTPPreconditionFailed(content={
-        #     'reason': 'Missing task_id'
-        # })
+        raise HTTPPreconditionFailed(content={
+            'reason': 'Missing task_id'
+        })
 
     if await mngr.is_canceled(task_id):
         return {
@@ -79,11 +71,9 @@ async def cancel_task(context, request):
         }
 
     if not await mngr.exists(task_id):
-        raise HTTPNotFound(reason='Task unexisting task')
-        # TODO: replace for below to upgrade to g4
-        # raise HTTPNotFound(content={
-        #     'reason': 'Task not found'
-        # })
+        raise HTTPNotFound(content={
+            'reason': 'Task not found'
+        })
 
     if await mngr.cancel(task_id):
         return {

--- a/guillotina_amqp/commands/worker.py
+++ b/guillotina_amqp/commands/worker.py
@@ -4,36 +4,49 @@ from guillotina_amqp.worker import Worker
 import aiotask_context
 import asyncio
 import logging
-import sys
-import time
 import threading
 import os
 
 
 logger = logging.getLogger('guillotina_amqp')
 
+
 class EventLoopWatchdog(threading.Thread):
+    """Takes care of exiting worker after specified loop no-activity
+    timeout for the worker loop.
+
+    This prevents a task from taking the asynio loop forever and
+    preventing other tasks to run. If a task hangs, the watchdog will
+    exit the worker and unfinished jobs will be retaken by other
+    workers.
+
+    """
     def __init__(self, loop, timeout):
         super().__init__()
         self.loop = loop
         self.timeout = timeout * 60  # In seconds
+        # Start time
         self._time = loop.time()
 
     def check(self):
+        # Elapsed time since last update
         diff = self.loop.time() - self._time
 
         if diff > self.timeout:
             logger.error(f'Exiting worker because no activity in {diff} seconds')
             os._exit(1)
         else:
+            # Schedule a check again
             threading.Timer(self.timeout/4, self.check).start()
             logger.debug(f'Last refreshed watchdog was {diff}s. ago')
 
-    # This method just to trigger a context switching in the event loop in
-    # and sense the delta between the ideal timeout (10s)
     async def probe(self):
+        """This method just to trigger a context switching in the event loop
+        in and sense the delta between the ideal timeout (10s)
+        """
         while True:
             await asyncio.sleep(10)
+            # Update the watchdog time
             self._time = self.loop.time()
 
     def run(self):
@@ -42,6 +55,7 @@ class EventLoopWatchdog(threading.Thread):
 
 
 class WorkerCommand(Command):
+    """Guillotina command to start a worker"""
     description = 'AMQP worker'
 
     def get_parser(self):

--- a/guillotina_amqp/exceptions.py
+++ b/guillotina_amqp/exceptions.py
@@ -14,5 +14,9 @@ class TaskAlreadyCanceled(Exception):
     pass
 
 
+class TaskAccessUnauthorized(Exception):
+    pass
+
+
 class TaskMaxRetriesReached(Exception):
     pass

--- a/guillotina_amqp/exceptions.py
+++ b/guillotina_amqp/exceptions.py
@@ -10,5 +10,9 @@ class TaskAlreadyAcquired(Exception):
     pass
 
 
-class TaskAlreadyCancelled(Exception):
+class TaskAlreadyCanceled(Exception):
+    pass
+
+
+class TaskMaxRetriesReached(Exception):
     pass

--- a/guillotina_amqp/exceptions.py
+++ b/guillotina_amqp/exceptions.py
@@ -8,3 +8,7 @@ class TaskNotFoundException(Exception):
 
 class TaskAlreadyAcquired(Exception):
     pass
+
+
+class TaskAlreadyCancelled(Exception):
+    pass

--- a/guillotina_amqp/exceptions.py
+++ b/guillotina_amqp/exceptions.py
@@ -1,8 +1,10 @@
-
-
 class TaskNotFinishedException(Exception):
     pass
 
 
 class TaskNotFoundException(Exception):
+    pass
+
+
+class TaskAlreadyAcquired(Exception):
     pass

--- a/guillotina_amqp/interfaces.py
+++ b/guillotina_amqp/interfaces.py
@@ -4,19 +4,40 @@ from zope.interface import Interface
 
 class IStateManagerUtility(Interface):
     async def update(task_id, data):
-        pass
+        """Updates data related to task id into state manager
+        """
+        raise NotImplementedError()
 
     async def get(self, task_id):
-        pass
+        """Gets whatever was stored in state manager for task_id
+        """
+        raise NotImplementedError()
 
     async def list(self):
-        if False: yield
+        """
+        Yields items from the list of stored items
+        """
+        raise NotImplementedError()
 
-    async def lock(self, task_id, timeout=None, ttl=None):
-        pass
+    async def cancel(self, task_id):
+        """
+        Sets task_id to the canceled set of tasks
+        """
+        raise NotImplementedError()
 
-    async def unlock(self, task_id):
-        pass
+    async def cancelation_list(self):
+        """
+        Yields items from the canceled set
+        """
+        raise NotImplementedError()
+
+    async def clean_canceled(self, task_id):
+        """
+        Removes a task from the canceled set
+        """
+        raise NotImplementedError()
+
+
 
 class ITaskDefinition(Interface):
     func = Attribute('actual function to run')

--- a/guillotina_amqp/interfaces.py
+++ b/guillotina_amqp/interfaces.py
@@ -25,6 +25,16 @@ class IStateManagerUtility(Interface):
         """
         raise NotImplementedError()
 
+    async def acquire(self, task_id, ttl=None):
+        """
+        """
+        raise NotImplementedError()
+
+    async def release(self, task_id):
+        """
+        """
+        raise NotImplementedError()
+
     async def cancelation_list(self):
         """
         Yields items from the canceled set

--- a/guillotina_amqp/interfaces.py
+++ b/guillotina_amqp/interfaces.py
@@ -24,6 +24,11 @@ class IStateManagerUtility(Interface):
         """
         raise NotImplementedError()
 
+    async def is_mine(self, task_id):
+        """Returns whether the worker has a lock on a given task_idq
+        """
+        raise NotImplementedError()
+
     async def cancel(self, task_id):
         """
         Sets task_id to the canceled set of tasks

--- a/guillotina_amqp/interfaces.py
+++ b/guillotina_amqp/interfaces.py
@@ -13,6 +13,11 @@ class IStateManagerUtility(Interface):
         """
         raise NotImplementedError()
 
+    async def exists(self, task_id):
+        """Returns whether a task id exists in the state manager
+        """
+        raise NotImplementedError()
+
     async def list(self):
         """
         Yields items from the list of stored items
@@ -55,6 +60,11 @@ class IStateManagerUtility(Interface):
         """
         raise NotImplementedError()
 
+    async def is_canceled(self, task_id):
+        """
+        Whether a task id has been cancelled
+        """
+        raise NotImplementedError()
 
 
 class ITaskDefinition(Interface):

--- a/guillotina_amqp/interfaces.py
+++ b/guillotina_amqp/interfaces.py
@@ -25,13 +25,21 @@ class IStateManagerUtility(Interface):
         """
         raise NotImplementedError()
 
-    async def acquire(self, task_id, ttl=None):
+    async def acquire(self, task_id, ttl):
         """
+        Get a lock on a certain task, by id.
         """
         raise NotImplementedError()
 
     async def release(self, task_id):
         """
+        Release the lock for the specified task
+        """
+        raise NotImplementedError()
+
+    async def refresh_lock(self, task_id, ttl):
+        """
+        Update lock TTL
         """
         raise NotImplementedError()
 

--- a/guillotina_amqp/job.py
+++ b/guillotina_amqp/job.py
@@ -22,8 +22,8 @@ from zope.interface import alsoProvides
 
 import aiotask_context
 import logging
-import traceback
 import yarl
+import asyncio
 
 
 logger = logging.getLogger('guillotina_amqp')
@@ -181,7 +181,8 @@ class Job:
             committed = True
 
             self.task.set_result(result)
-        except CancelledError as e:
+
+        except asyncio.CancelledError as e:
             logger.warning(f'Cancelled task: {self.data}', exc_info=True)
             self.task.set_exception(e)
 

--- a/guillotina_amqp/state.py
+++ b/guillotina_amqp/state.py
@@ -96,9 +96,10 @@ class MemoryStateManager:
     async def clean_canceled(self, task_id):
         try:
             self._canceled.remove(task_id)
+            return True
         except KeyError:
             # Task id wasn't canceled
-            pass
+            return False
 
 
 

--- a/guillotina_amqp/state.py
+++ b/guillotina_amqp/state.py
@@ -47,7 +47,7 @@ class MemoryStateManager:
         return self._data.get(task_id, {})
 
     async def exists(self, task_id):
-        return task_id in self.data
+        return task_id in self._data
 
     async def list(self):
         for task_id in self._data.keys():
@@ -160,6 +160,7 @@ class RedisStateManager:
             value = await cache.get(self._cache_prefix + task_id)
             if value:
                 return json.loads(value)
+        return {}
 
     async def exists(self, task_id):
         data = await self.get(task_id)

--- a/guillotina_amqp/state.py
+++ b/guillotina_amqp/state.py
@@ -34,7 +34,8 @@ class MemoryStateManager:
     Meaningless for anyting other than tests
     '''
     def __init__(self, size=10):
-        self._data = LRU(size)
+        self.size = size
+        self._data = LRU(self.size)
         self._locks = {}
         self._canceled = set()
         self.worker_id = uuid.uuid4().hex
@@ -121,6 +122,11 @@ class MemoryStateManager:
 
     async def is_canceled(self, task_id):
         return task_id in self._canceled
+
+    async def _clean(self):
+        self._data = LRU(self.size)
+        self._locks = {}
+        self._canceled = set()
 
 
 _EMPTY = object()
@@ -280,6 +286,9 @@ class RedisStateManager:
             if tid == task_id:
                 return True
         return False
+
+    async def _clean(self):
+        await self._cache.flushall()
 
 
 class TaskState:

--- a/guillotina_amqp/state.py
+++ b/guillotina_amqp/state.py
@@ -23,7 +23,7 @@ except ImportError:
     aioredis = None
 
 
-logger = logging.getLogger('guillotina_amqp')
+logger = logging.getLogger('guillotina_amqp.state')
 
 DEFAULT_LOCK_TTL_S = 120
 
@@ -296,7 +296,7 @@ class TaskState:
             data = await util.get(self.task_id)
             if not data:
                 raise TaskNotFoundException(self.task_id)
-            if data.get('status') in ('finished', 'errored'):
+            if data.get('status') in ('finished', 'errored', 'canceled'):
                 return data
             await asyncio.sleep(wait)
 
@@ -312,6 +312,7 @@ class TaskState:
         possible statuses:
         - scheduled
         - consumed
+        - canceled
         - running
         - finished
         - errored

--- a/guillotina_amqp/tests/__init__.py
+++ b/guillotina_amqp/tests/__init__.py
@@ -1,0 +1,7 @@
+import logging
+from guillotina_amqp.job import logger as logger_job
+from guillotina_amqp.worker import logger as logger_worker
+
+logging.basicConfig()
+logger_job.setLevel(10)
+logger_worker.setLevel(10)

--- a/guillotina_amqp/tests/conftest.py
+++ b/guillotina_amqp/tests/conftest.py
@@ -1,4 +1,5 @@
 pytest_plugins = [
     'guillotina.tests.fixtures',
     'guillotina_amqp.tests.fixtures',
+    'pytest_docker_fixtures',
 ]

--- a/guillotina_amqp/tests/fixtures.py
+++ b/guillotina_amqp/tests/fixtures.py
@@ -1,7 +1,6 @@
 from guillotina import testing
 import pytest
 from guillotina_amqp.worker import Worker
-from guillotina_amqp.commands.worker import EventLoopWatchdog
 from guillotina import app_settings
 
 
@@ -43,14 +42,6 @@ def amqp_worker(loop):
         loop.run_until_complete(conn['protocol'].close())
     _worker.cancel()
     app_settings['amqp']['connections'] = {}
-
-
-@pytest.fixture('function')
-def amqp_watchdog(loop):
-    thread = EventLoopWatchdog(loop, timeout=20)
-    thread.start()
-    yield thread
-    thread.join()
 
 
 @pytest.fixture('function', params=[

--- a/guillotina_amqp/tests/fixtures.py
+++ b/guillotina_amqp/tests/fixtures.py
@@ -79,7 +79,7 @@ def configured_state_manager(request, redis, dummy_request, loop):
         print('Running with memory')
         yield
 
-        
+
 @pytest.fixture('function')
 async def amqp_queues(dummy_request):
     channel, transport, protocol = await amqp.get_connection()

--- a/guillotina_amqp/tests/fixtures.py
+++ b/guillotina_amqp/tests/fixtures.py
@@ -21,7 +21,7 @@ def base_settings_configurator(settings):
         "heartbeat": 800,
         "exchange": "",
         "queue": "guillotina",
-        "persistent_manager": "memory"
+        "persistent_manager": "memory",
     }
 
 
@@ -58,7 +58,7 @@ def configured_state_manager(request, redis_enabled, redis_disabled):
 
 
 @pytest.fixture('function')
-def redis_enabled(redis, dummy_request):
+def redis_enabled(redis):
     app_settings['amqp']['persistent_manager'] = 'redis'
     app_settings['redis_prefix_key'] = 'amqpjobs-'
     app_settings.update({"redis": {
@@ -73,6 +73,6 @@ def redis_enabled(redis, dummy_request):
 
 
 @pytest.fixture('function')
-def redis_disabled(dummy_request):
+def redis_disabled():
     app_settings['amqp']['persistent_manager'] = 'memory'
     yield

--- a/guillotina_amqp/tests/fixtures.py
+++ b/guillotina_amqp/tests/fixtures.py
@@ -61,7 +61,7 @@ def configured_state_manager(request, redis_enabled, redis_disabled):
 def redis_enabled(redis, dummy_request):
     app_settings['amqp']['persistent_manager'] = 'redis'
     app_settings['redis_prefix_key'] = 'amqpjobs-'
-    app_settings.update({"redis":{
+    app_settings.update({"redis": {
         'host': redis[0],
         'port': redis[1],
         'pool': {

--- a/guillotina_amqp/tests/fixtures.py
+++ b/guillotina_amqp/tests/fixtures.py
@@ -43,6 +43,19 @@ def amqp_worker(loop):
     app_settings['amqp']['connections'] = {}
 
 
+@pytest.fixture('function', params=[
+    {'redis_up': False},
+    {'redis_up': True}
+])
+def configured_state_manager(request, redis_enabled, redis_disabled):
+    if request.param.get('redis_up'):
+        # Redis
+        yield redis_enabled
+    else:
+        # Memory
+        yield redis_disabled
+
+
 @pytest.fixture('function')
 def redis_enabled(redis, dummy_request):
     app_settings['amqp']['persistent_manager'] = 'redis'
@@ -56,3 +69,9 @@ def redis_enabled(redis, dummy_request):
         },
     }})
     yield redis
+
+
+@pytest.fixture('function')
+def redis_disabled(dummy_request):
+    app_settings['amqp']['persistent_manager'] = 'memory'
+    yield

--- a/guillotina_amqp/tests/fixtures.py
+++ b/guillotina_amqp/tests/fixtures.py
@@ -1,6 +1,7 @@
 from guillotina import testing
 import pytest
 from guillotina_amqp.worker import Worker
+from guillotina_amqp import amqp
 from guillotina import app_settings
 import uuid
 
@@ -72,9 +73,14 @@ def configured_state_manager(request, redis, dummy_request, loop):
         # loops, which causes its to crash
         from guillotina_rediscache.cache import close_redis_pool
         loop.run_until_complete(close_redis_pool())
-
     else:
         # Memory
         app_settings['amqp']['persistent_manager'] = 'memory'
         print('Running with memory')
         yield
+
+        
+@pytest.fixture('function')
+async def amqp_queues(dummy_request):
+    channel, transport, protocol = await amqp.get_connection()
+    return protocol.queues

--- a/guillotina_amqp/tests/fixtures.py
+++ b/guillotina_amqp/tests/fixtures.py
@@ -14,7 +14,7 @@ base_amqp_settings = {
     "heartbeat": 800,
     "exchange": "",
     "queue": "guillotina",
-    "persistent_manager": "memoryee",
+    "persistent_manager": "memory",
 }
 
 

--- a/guillotina_amqp/tests/fixtures.py
+++ b/guillotina_amqp/tests/fixtures.py
@@ -88,7 +88,7 @@ async def amqp_channel():
 
 @pytest.fixture('function')
 def rabbitmq_container(rabbitmq):
-    app_settings['amqp'] = {
+    app_settings['amqp'].update({
         "connection_factory": "aioamqp.connect",
         "host": rabbitmq[0],
         "port": rabbitmq[1],
@@ -98,5 +98,4 @@ def rabbitmq_container(rabbitmq):
         "heartbeat": 800,
         "exchange": "guillotina",
         "queue": "guillotina",
-        "persistent_manager": "memory"
-    }
+    })

--- a/guillotina_amqp/tests/fixtures.py
+++ b/guillotina_amqp/tests/fixtures.py
@@ -33,7 +33,7 @@ testing.configure_with(base_settings_configurator)
 
 
 @pytest.fixture('function')
-def amqp_worker(loop):
+def amqp_worker(loop, rabbitmq_container):
     # Create worker
     _worker = Worker(loop=loop)
     _worker.update_status_interval = 2
@@ -81,6 +81,22 @@ def configured_state_manager(request, redis, dummy_request, loop):
 
 
 @pytest.fixture('function')
-async def amqp_queues(dummy_request):
+async def amqp_channel():
     channel, transport, protocol = await amqp.get_connection()
-    return protocol.queues
+    return channel
+
+
+@pytest.fixture('function')
+def rabbitmq_container(rabbitmq):
+    app_settings['amqp'] = {
+        "connection_factory": "aioamqp.connect",
+        "host": rabbitmq[0],
+        "port": rabbitmq[1],
+        "login": "guest",
+        "password": "guest",
+        "vhost": "/",
+        "heartbeat": 800,
+        "exchange": "guillotina",
+        "queue": "guillotina",
+        "persistent_manager": "memory"
+    }

--- a/guillotina_amqp/tests/package.py
+++ b/guillotina_amqp/tests/package.py
@@ -2,6 +2,8 @@ from guillotina import configure
 from guillotina_amqp.utils import add_object_task
 from guillotina_amqp.utils import add_task
 
+import asyncio
+
 
 async def task_foobar_yo(one, two, three='blah'):
     return one + two
@@ -10,6 +12,13 @@ async def task_foobar_yo(one, two, three='blah'):
 async def task_object_write(ob, value):
     ob.title = value
     ob._p_register()
+    return 'done!'
+
+
+async def task_long_running(duration):
+    print('Started task')
+    await asyncio.sleep(duration)
+    print('Finished task')
     return 'done!'
 
 
@@ -29,5 +38,17 @@ async def foobar_write(context, request):
     return {
         'task_id': (
             await add_object_task(task_object_write, context, 'Foobar written')
+        ).task_id
+    }
+
+
+@configure.service(name='@foobar-long', method='GET')
+async def foobar_long(context, request):
+    # Endpoint to be used in tests to add an object function task
+    # Get duration from query params
+    duration_s = int(request.GET.get('duration', '60'))
+    return {
+        'task_id': (
+            await add_task(task_long_running, duration_s)
         ).task_id
     }

--- a/guillotina_amqp/tests/package.py
+++ b/guillotina_amqp/tests/package.py
@@ -15,6 +15,7 @@ async def task_object_write(ob, value):
 
 @configure.service(name='@foobar', method='GET')
 async def foobar(context, request):
+    # Endpoint to be used in tests to add a function task
     return {
         'task_id': (
             await add_task(task_foobar_yo, 1, 2, three='hello!')
@@ -24,6 +25,7 @@ async def foobar(context, request):
 
 @configure.service(name='@foobar-write', method='GET')
 async def foobar_write(context, request):
+    # Endpoint to be used in tests to add an object function task
     return {
         'task_id': (
             await add_object_task(task_object_write, context, 'Foobar written')

--- a/guillotina_amqp/tests/package.py
+++ b/guillotina_amqp/tests/package.py
@@ -2,8 +2,6 @@ from guillotina import configure
 from guillotina_amqp.utils import add_object_task
 from guillotina_amqp.utils import add_task
 
-import asyncio
-
 
 async def task_foobar_yo(one, two, three='blah'):
     return one + two
@@ -12,13 +10,6 @@ async def task_foobar_yo(one, two, three='blah'):
 async def task_object_write(ob, value):
     ob.title = value
     ob._p_register()
-    return 'done!'
-
-
-async def task_long_running(duration):
-    print('Started task')
-    await asyncio.sleep(duration)
-    print('Finished task')
     return 'done!'
 
 
@@ -38,17 +29,5 @@ async def foobar_write(context, request):
     return {
         'task_id': (
             await add_object_task(task_object_write, context, 'Foobar written')
-        ).task_id
-    }
-
-
-@configure.service(name='@foobar-long', method='GET')
-async def foobar_long(context, request):
-    # Endpoint to be used in tests to add an object function task
-    # Get duration from query params
-    duration_s = int(request.GET.get('duration', '60'))
-    return {
-        'task_id': (
-            await add_task(task_long_running, duration_s)
         ).task_id
     }

--- a/guillotina_amqp/tests/test_amqp.py
+++ b/guillotina_amqp/tests/test_amqp.py
@@ -1,28 +1,14 @@
 from guillotina import app_settings
-from guillotina_amqp.decorators import task
 from guillotina_amqp.state import TaskState
 from guillotina_amqp.utils import add_task
 from guillotina_amqp.utils import cancel_task
+from guillotina_amqp.tests.utils import _test_func
+from guillotina_amqp.tests.utils import _test_long_func
+from guillotina_amqp.tests.utils import _decorator_test_func
 
 import aiotask_context
 import asyncio
 import json
-
-
-async def _test_func(one, two, one_keyword=None):
-    return one + two
-
-
-async def _test_long_func(duration):
-    print('Started task')
-    await asyncio.sleep(duration)
-    print('Finished task')
-    return 'done!'
-
-
-@task
-async def _decorator_test_func(one, two):
-    return one + two
 
 
 async def test_add_task(dummy_request, amqp_worker):
@@ -73,8 +59,7 @@ async def test_task_commits_data_from_service(amqp_worker, container_requester):
 async def test_cancels_long_running_task(dummy_request, amqp_worker, configured_state_manager):
     aiotask_context.set('request', dummy_request)
     # Add long running task
-    ts = await add_task(_test_long_func, 120)
-
+    ts = await _test_long_func(120)
     # Wait a bit and cancel
     await asyncio.sleep(1)
     success = await cancel_task(ts.task_id)

--- a/guillotina_amqp/tests/test_amqp.py
+++ b/guillotina_amqp/tests/test_amqp.py
@@ -4,6 +4,7 @@ from guillotina_amqp.utils import add_task
 from guillotina_amqp.utils import cancel_task
 from guillotina_amqp.tests.utils import _test_func
 from guillotina_amqp.tests.utils import _test_long_func
+from guillotina_amqp.tests.utils import _test_failing_func
 from guillotina_amqp.tests.utils import _decorator_test_func
 
 import aiotask_context
@@ -86,4 +87,15 @@ async def test_decorator_task(dummy_request, amqp_worker):
     assert amqp_worker.total_run == 1
     assert await state.get_status() == 'finished'
     assert await state.get_result() == 3
+    aiotask_context.set('request', None)
+
+
+async def test_worker_retries_should_not_exceed_the_limit(dummy_request, amqp_worker):
+    aiotask_context.set('request', dummy_request)
+    ts = await _test_failing_func()
+    # wait for it to finish
+    await ts.join(0.1)
+    assert amqp_worker.total_run == 1
+    import pdb; pdb.set_trace()
+
     aiotask_context.set('request', None)

--- a/guillotina_amqp/tests/test_amqp.py
+++ b/guillotina_amqp/tests/test_amqp.py
@@ -2,6 +2,7 @@ from guillotina import app_settings
 from guillotina_amqp.decorators import task
 from guillotina_amqp.state import TaskState
 from guillotina_amqp.utils import add_task
+from guillotina_amqp.utils import cancel_task
 
 import aiotask_context
 import asyncio
@@ -10,6 +11,13 @@ import json
 
 async def _test_func(one, two, one_keyword=None):
     return one + two
+
+
+async def _test_long_func(duration):
+    print('Started task')
+    await asyncio.sleep(duration)
+    print('Finished task')
+    return 'done!'
 
 
 @task
@@ -60,6 +68,28 @@ async def test_task_commits_data_from_service(amqp_worker, container_requester):
         assert amqp_worker.total_run == 1
         resp, status = await requester('GET', '/db/guillotina/foobar')
         assert resp['title'] == 'Foobar written'
+
+
+async def test_cancels_long_running_task(dummy_request, amqp_worker, configured_state_manager):
+    aiotask_context.set('request', dummy_request)
+    # Add long running task
+    ts = await add_task(_test_long_func, 120)
+
+    # Wait a bit and cancel
+    await asyncio.sleep(1)
+    success = await cancel_task(ts.task_id)
+    assert success
+    # Wait until worker sees task is cancelled and cancels the
+    # asycio task
+    await ts.join(0.2)
+
+    # Check that the it was indeed cancelled
+    state = await ts.get_state()
+    assert state['status'] == 'errored'
+    assert 'CancelledError' in state['error']
+    await asyncio.sleep(0.1)  # prevent possible race condition here
+    assert amqp_worker.total_run == 1
+    aiotask_context.set('request', None)
 
 
 async def test_decorator_task(dummy_request, amqp_worker):

--- a/guillotina_amqp/tests/test_amqp.py
+++ b/guillotina_amqp/tests/test_amqp.py
@@ -176,10 +176,8 @@ async def test_worker_retries_should_not_exceed_the_limit(dummy_request,
 
     # Check that it went to error queue
     main_queue = await amqp_worker.queue_main(amqp_channel)
-    delayed_queue = await amqp_worker.queue_delayed(amqp_channel)
     errored_queue = await amqp_worker.queue_errored(amqp_channel)
     assert main_queue['consumer_count'] == 1
-    assert delayed_queue['message_count'] == 0
     assert errored_queue['message_count'] == 1
 
     aiotask_context.set('request', None)

--- a/guillotina_amqp/tests/test_amqp.py
+++ b/guillotina_amqp/tests/test_amqp.py
@@ -96,6 +96,4 @@ async def test_worker_retries_should_not_exceed_the_limit(dummy_request, amqp_wo
     # wait for it to finish
     await ts.join(0.1)
     assert amqp_worker.total_run == 1
-    import pdb; pdb.set_trace()
-
     aiotask_context.set('request', None)

--- a/guillotina_amqp/tests/test_api.py
+++ b/guillotina_amqp/tests/test_api.py
@@ -31,7 +31,7 @@ async def test_info_task(container_requester, dummy_request):
         # Check error status if task_id not specified
         resp, status = await requester('GET', '/db/guillotina/@amqp-info')
         assert status == 412
-        assert 'Missing task_id' in resp.decode()
+        assert resp['reason'] == 'Missing task_id'
 
         # Check returns correctly if existing task_id
         resp, status = await requester(
@@ -43,7 +43,7 @@ async def test_info_task(container_requester, dummy_request):
         resp, status = await requester(
             'GET', f'/db/guillotina/@amqp-info?task_id=foo')
         assert status == 404
-        assert 'Task not found' in resp.decode()
+        assert resp['reason'] == 'Task not found'
 
     aiotask_context.set('request', None)
 
@@ -59,7 +59,7 @@ async def test_cancel_task(container_requester, dummy_request):
         resp, status = await requester(
             'DELETE', '/db/guillotina/@amqp-cancel')
         assert status == 412
-        assert 'Missing task_id' in resp.decode()
+        assert resp['reason'] == 'Missing task_id'
 
         # Check returns correctly if existing task_id
         resp, status = await requester(

--- a/guillotina_amqp/tests/test_api.py
+++ b/guillotina_amqp/tests/test_api.py
@@ -3,6 +3,7 @@ from guillotina_amqp.tests.utils import _test_func
 
 import aiotask_context
 
+
 async def test_list_tasks_returns_all_tasks(container_requester, dummy_request):
     aiotask_context.set('request', dummy_request)
 
@@ -64,7 +65,7 @@ async def test_cancel_task(container_requester, dummy_request):
         resp, status = await requester(
             'DELETE', f'/db/guillotina/@amqp-cancel?task_id={t1.task_id}')
         assert status == 200
-        assert resp['ok'] # success
+        assert resp['ok']  # success
 
         # Check returns correctly if already canceled task_id
         resp, status = await requester(
@@ -77,6 +78,5 @@ async def test_cancel_task(container_requester, dummy_request):
         resp, status = await requester(
             'DELETE', f'/db/guillotina/@amqp-cancel?task_id=foo')
         assert status == 404
-
 
     aiotask_context.set('request', None)

--- a/guillotina_amqp/tests/test_api.py
+++ b/guillotina_amqp/tests/test_api.py
@@ -1,0 +1,75 @@
+from guillotina_amqp.utils import add_task
+from guillotina_amqp.tests.utils import _test_func
+
+import aiotask_context
+
+async def test_list_tasks_returns_all_tasks(container_requester, dummy_request):
+    aiotask_context.set('request', dummy_request)
+
+    # Add some tasks first
+    t1 = await add_task(_test_func, 1, 2)
+    t2 = await add_task(_test_func, 3, 4)
+
+    async with container_requester as requester:
+        resp, status = await requester('GET', '/db/guillotina/@amqp-tasks')
+        assert status == 200
+        assert len(resp) == 2
+        assert t1.task_id in resp
+        assert t2.task_id in resp
+
+    aiotask_context.set('request', None)
+
+
+async def test_info_task(container_requester, dummy_request):
+    aiotask_context.set('request', dummy_request)
+
+    # Add some tasks first
+    t1 = await add_task(_test_func, 1, 2)
+
+    async with container_requester as requester:
+        # Check error status if task_id not specified
+        resp, status = await requester('GET', '/db/guillotina/@amqp-info')
+        assert status == 412
+        assert 'Missing task_id' in resp.decode()
+
+        # Check returns correctly if existing task_id
+        resp, status = await requester(
+            'GET', f'/db/guillotina/@amqp-info?task_id={t1.task_id}')
+        assert status == 200
+        assert resp['status'] == 'scheduled'
+
+        # Check returns 404 if task_id is not known
+        resp, status = await requester(
+            'GET', f'/db/guillotina/@amqp-info?task_id=foo')
+        assert status == 404
+        assert 'Task not found' in resp.decode()
+
+    aiotask_context.set('request', None)
+
+
+async def test_cancel_task(container_requester, dummy_request):
+    aiotask_context.set('request', dummy_request)
+
+    # Add some tasks first
+    t1 = await add_task(_test_func, 1, 2)
+
+    async with container_requester as requester:
+        # Check error status if task_id not specified
+        resp, status = await requester(
+            'DELETE', '/db/guillotina/@amqp-cancel')
+        assert status == 412
+        assert 'Missing task_id' in resp.decode()
+
+        # Check returns correctly if existing task_id
+        resp, status = await requester(
+            'DELETE', f'/db/guillotina/@amqp-cancel?task_id={t1.task_id}')
+        assert status == 200
+        assert resp['ok'] # success
+
+        # Check returns success if False
+        resp, status = await requester(
+            'DELETE', f'/db/guillotina/@amqp-cancel?task_id=foo')
+        assert status == 200
+        assert resp['ok'] in (True, False)
+
+    aiotask_context.set('request', None)

--- a/guillotina_amqp/tests/test_api.py
+++ b/guillotina_amqp/tests/test_api.py
@@ -66,10 +66,17 @@ async def test_cancel_task(container_requester, dummy_request):
         assert status == 200
         assert resp['ok'] # success
 
-        # Check returns success if False
+        # Check returns correctly if already canceled task_id
+        resp, status = await requester(
+            'DELETE', f'/db/guillotina/@amqp-cancel?task_id={t1.task_id}')
+        assert status == 200
+        assert resp['ok']
+        assert resp['info'] == 'already canceled'
+
+        # Check returns 404 is unknown task
         resp, status = await requester(
             'DELETE', f'/db/guillotina/@amqp-cancel?task_id=foo')
-        assert status == 200
-        assert resp['ok'] in (True, False)
+        assert status == 404
+
 
     aiotask_context.set('request', None)

--- a/guillotina_amqp/tests/test_state.py
+++ b/guillotina_amqp/tests/test_state.py
@@ -61,4 +61,4 @@ async def test_clean_cancel_should_clean_from_canceled_list(configured_state_man
     assert 'foo' not in canceled_list
 
 
-#async def test_task_
+# async def test_task_

--- a/guillotina_amqp/tests/test_state.py
+++ b/guillotina_amqp/tests/test_state.py
@@ -1,0 +1,52 @@
+from guillotina_amqp.state import get_state_manager
+from guillotina_amqp.exceptions import TaskAlreadyAcquired
+
+import pytest
+
+
+async def test_update_and_get_should_match(configured_state_manager):
+    state_manager = get_state_manager()
+    await state_manager.update('foo', {'state': 'bar'})
+    data = await state_manager.get('foo')
+    assert data['state'] == 'bar'
+
+
+async def test_acquire_should_block_further_acquires(configured_state_manager):
+    state_manager = get_state_manager()
+    await state_manager.acquire('foo')
+    with pytest.raises(TaskAlreadyAcquired):
+        await state_manager.acquire('foo')
+    # Release it and acquire again
+    await state_manager.release('foo')
+    await state_manager.acquire('foo')
+
+
+async def test_list_should_yield_all_items(configured_state_manager):
+    state_manager = get_state_manager()
+    tasks = set({'t1', 't2', 't3', 't4', 't5'})
+    for task_id in tasks:
+        await state_manager.update(task_id, {'state': f'{task_id} is OK!'})
+    assert set([tid async for tid in state_manager.list()]) == tasks
+
+
+async def test_cancel_should_put_tasks_in_cancelation_list(configured_state_manager):
+    state_manager = get_state_manager()
+    await state_manager.update('foo', {'status': 'bar'})
+    canceled_list = [tid async for tid in state_manager.cancelation_list()]
+    assert 'foo' not in canceled_list
+    await state_manager.cancel('foo')
+    canceled_list = [tid async for tid in state_manager.cancelation_list()]
+    assert 'foo' in canceled_list
+
+
+async def test_clean_cancel_should_clean_from_canceled_list(configured_state_manager):
+    state_manager = get_state_manager()
+    await state_manager.cancel('foo')
+    canceled_list = [tid async for tid in state_manager.cancelation_list()]
+    assert 'foo' in canceled_list
+    await state_manager.clean_canceled('foo')
+    canceled_list = [tid async for tid in state_manager.cancelation_list()]
+    assert 'foo' not in canceled_list
+
+
+#async def test_task_

--- a/guillotina_amqp/tests/test_state.py
+++ b/guillotina_amqp/tests/test_state.py
@@ -6,11 +6,16 @@ import pytest
 import asyncio
 
 
+async def clear_cache(sm):
+    await sm._clean()
+
+
 async def test_update_and_get_should_match(configured_state_manager, loop):
     state_manager = get_state_manager(loop)
     await state_manager.update('foo', {'state': 'bar'})
     data = await state_manager.get('foo')
     assert data['state'] == 'bar'
+    await clear_cache(state_manager)
 
 
 async def test_acquire_should_block_further_acquires(configured_state_manager, loop):
@@ -22,6 +27,7 @@ async def test_acquire_should_block_further_acquires(configured_state_manager, l
     # Release it and acquire again
     await state_manager.release('foo')
     await state_manager.acquire('foo', ttl=FOREVER)
+    await clear_cache(state_manager)
 
 
 async def test_acquire_should_unblock_after_ttl(configured_state_manager, loop):
@@ -32,6 +38,7 @@ async def test_acquire_should_unblock_after_ttl(configured_state_manager, loop):
     # Wait for the ttl and check
     await asyncio.sleep(1.1)
     await state_manager.acquire('foo', ttl=1)
+    await clear_cache(state_manager)
 
 
 async def test_list_should_yield_all_items(configured_state_manager, loop):
@@ -40,6 +47,7 @@ async def test_list_should_yield_all_items(configured_state_manager, loop):
     for task_id in tasks:
         await state_manager.update(task_id, {'state': f'{task_id} is OK!'})
     assert set([tid async for tid in state_manager.list()]) == tasks
+    await clear_cache(state_manager)
 
 
 async def test_cancel_should_put_tasks_in_cancelation_list(configured_state_manager, loop):
@@ -50,6 +58,7 @@ async def test_cancel_should_put_tasks_in_cancelation_list(configured_state_mana
     await state_manager.cancel('foo')
     canceled_list = [tid async for tid in state_manager.cancelation_list()]
     assert 'foo' in canceled_list
+    await clear_cache(state_manager)
 
 
 async def test_clean_cancel_should_clean_from_canceled_list(configured_state_manager, loop):
@@ -60,6 +69,7 @@ async def test_clean_cancel_should_clean_from_canceled_list(configured_state_man
     await state_manager.clean_canceled('foo')
     canceled_list = [tid async for tid in state_manager.cancelation_list()]
     assert 'foo' not in canceled_list
+    await clear_cache(state_manager)
 
 
 async def test_is_canceled_should_return_true_only_on_canceled_tasks(configured_state_manager, loop):
@@ -67,6 +77,7 @@ async def test_is_canceled_should_return_true_only_on_canceled_tasks(configured_
     await state_manager.cancel('foo')
     assert await state_manager.is_canceled('foo')
     assert not await state_manager.is_canceled('bar')
+    await clear_cache(state_manager)
 
 
 async def test_refresh_should_raise_if_task_is_not_yours(configured_state_manager, loop):
@@ -79,6 +90,7 @@ async def test_refresh_should_raise_if_task_is_not_yours(configured_state_manage
         await state_manager.refresh_lock('footask', 120)
     state_manager.worker_id = 'me'
     await state_manager.refresh_lock('footask', 20)
+    await clear_cache(state_manager)
 
 
 async def test_release_should_raise_if_task_is_not_yours(configured_state_manager, loop):
@@ -90,3 +102,4 @@ async def test_release_should_raise_if_task_is_not_yours(configured_state_manage
         await state_manager.release('footask')
     state_manager.worker_id = 'me'
     await state_manager.release('footask')
+    await clear_cache(state_manager)

--- a/guillotina_amqp/tests/test_state.py
+++ b/guillotina_amqp/tests/test_state.py
@@ -62,6 +62,13 @@ async def test_clean_cancel_should_clean_from_canceled_list(configured_state_man
     assert 'foo' not in canceled_list
 
 
+async def test_is_canceled_should_return_true_only_on_canceled_tasks(configured_state_manager, loop):
+    state_manager = get_state_manager(loop)
+    await state_manager.cancel('foo')
+    assert await state_manager.is_canceled('foo')
+    assert not await state_manager.is_canceled('bar')
+
+
 async def test_refresh_should_raise_if_task_is_not_yours(configured_state_manager, loop):
     state_manager = get_state_manager(loop)
     state_manager.worker_id = 'me'

--- a/guillotina_amqp/tests/utils.py
+++ b/guillotina_amqp/tests/utils.py
@@ -1,0 +1,18 @@
+from guillotina_amqp.decorators import task
+import asyncio
+
+async def _test_func(one, two, one_keyword=None):
+    return one + two
+
+
+@task
+async def _test_long_func(duration):
+    print('Started task')
+    await asyncio.sleep(duration)
+    print('Finished task')
+    return 'done!'
+
+
+@task
+async def _decorator_test_func(one, two):
+    return one + two

--- a/guillotina_amqp/tests/utils.py
+++ b/guillotina_amqp/tests/utils.py
@@ -14,5 +14,10 @@ async def _test_long_func(duration):
 
 
 @task
+async def _test_failing_func():
+    raise Exception('Foobar')
+
+
+@task
 async def _decorator_test_func(one, two):
     return one + two

--- a/guillotina_amqp/tests/utils.py
+++ b/guillotina_amqp/tests/utils.py
@@ -1,6 +1,7 @@
 from guillotina_amqp.decorators import task
 import asyncio
 
+
 async def _test_func(one, two, one_keyword=None):
     return one + two
 

--- a/guillotina_amqp/tests/utils.py
+++ b/guillotina_amqp/tests/utils.py
@@ -6,6 +6,24 @@ async def _test_func(one, two, one_keyword=None):
     return one + two
 
 
+async def _test_asyncgen(one, two, one_keyword=None):
+    yield (1, 'Starting task')
+    yield (1, 'Yellow')
+    yield (0, one + two)
+
+
+async def _test_asyncgen_invalid():
+    yield (1, 1, 2, 3)
+    yield (0)
+
+
+async def _test_asyncgen_doubley(arg1, arg2, arg3):
+    yield (0, arg1)
+    yield (0, arg2)
+    yield (1, 'OK')
+    yield (0, arg3)
+
+
 @task
 async def _test_long_func(duration):
     print('Started task')

--- a/guillotina_amqp/utils.py
+++ b/guillotina_amqp/utils.py
@@ -123,8 +123,9 @@ async def add_object_task(func, ob, *args, _request=None, _retries=3, **kwargs):
 
 class TimeoutLock(object):
     """Implements a Lock that can be acquired for """
-    def __init__(self):
+    def __init__(self, worker_id):
         self._lock = threading.Lock()
+        self.worker_id = worker_id
         self._thread = None
 
     def acquire(self, ttl=-1, blocking=True):

--- a/guillotina_amqp/utils.py
+++ b/guillotina_amqp/utils.py
@@ -22,6 +22,8 @@ from contextlib import contextmanager
 logger = logging.getLogger('guillotina_amqp')
 
 
+async def cancel_task(task_id, _retries=3):
+
 async def add_task(func, *args, _request=None, _retries=3, **kwargs):
     """Given a function and its arguments, it adds it as a task to be ran
     by workers.

--- a/guillotina_amqp/utils.py
+++ b/guillotina_amqp/utils.py
@@ -22,7 +22,14 @@ from contextlib import contextmanager
 logger = logging.getLogger('guillotina_amqp')
 
 
-async def cancel_task(task_id, _retries=3):
+async def cancel_task(task_id):
+    """It cancels a task by id. Returns wether it could be cancelled.
+
+    """
+    task = TaskState(task_id)
+    success = await task.cancel()
+    return success
+
 
 async def add_task(func, *args, _request=None, _retries=3, **kwargs):
     """Given a function and its arguments, it adds it as a task to be ran
@@ -130,3 +137,6 @@ class TimeoutLock(object):
 
     def release(self):
         self._lock.release()
+
+    def locked(self):
+        return self._lock.locked()

--- a/guillotina_amqp/utils.py
+++ b/guillotina_amqp/utils.py
@@ -19,7 +19,7 @@ import threading
 import asyncio
 
 
-logger = logging.getLogger('guillotina_amqp')
+logger = logging.getLogger('guillotina_amqp.utils')
 
 
 async def cancel_task(task_id):

--- a/guillotina_amqp/worker.py
+++ b/guillotina_amqp/worker.py
@@ -233,21 +233,24 @@ class Worker:
             type_name='direct',
             durable=True)
 
-        # Declare errored queue
+        # Declare errored queue and bind it
         await self.queue_errored(channel, passive=False)
+        await channel.queue_bind(
+            exchange_name=self.EXCHANGE,
+            queue_name=self.QUEUE_ERRORED,
+            routing_key=self.QUEUE_ERRORED,
+        )
 
-        # Declare main queue
+        # Declare main queue and bind it
         await self.queue_main(channel, passive=False)
-
         await channel.queue_bind(
             exchange_name=self.EXCHANGE,
             queue_name=self.QUEUE_MAIN,
             routing_key=self.QUEUE_MAIN,
         )
 
-        # Declare delayed queue
+        # Declare delayed queue and bind it
         await self.queue_delayed(channel, passive=False)
-
         await channel.queue_bind(
             exchange_name=self.EXCHANGE,
             queue_name=self.QUEUE_DELAYED,

--- a/guillotina_amqp/worker.py
+++ b/guillotina_amqp/worker.py
@@ -244,17 +244,12 @@ class Worker:
             routing_key=self.QUEUE_MAIN,
         )
 
-        # Declare delayed queue
+        # Declare delayed queue: set TTL to move taks from delayed
+        # queue to main queue
         await channel.queue_declare(
             queue_name=self.QUEUE_DELAYED, durable=True,
             arguments={
                 'x-message-ttl': self.TTL_DELAYED,
-            })
-
-        # Automatically move taks from delayed queue to main queue
-        await channel.queue_declare(
-            queue_name=self.QUEUE_DELAYED, durable=True,
-            arguments={
                 'x-dead-letter-exchange': self.EXCHANGE,
                 'x-dead-letter-routing-key': self.QUEUE_MAIN,
             })

--- a/guillotina_amqp/worker.py
+++ b/guillotina_amqp/worker.py
@@ -80,7 +80,8 @@ class Worker:
         task_id = data['task_id']
         dotted_name = data['func']
         await self.state_manager.update(task_id, {
-            'status': 'scheduled'
+            'status': 'scheduled',
+            'eventlog': {},
         })
         logger.info(f'Received task: {task_id}: {dotted_name}')
 
@@ -145,7 +146,7 @@ class Worker:
         # Update status to errored with the traceback
         await self.state_manager.update(task_id, {
             'status': 'errored',
-            'errors': task.print_stack(),
+            'error': task.print_stack(),
         })
 
     async def _handle_retry(self, task, current_retries):
@@ -155,12 +156,13 @@ class Worker:
         # Increment retry count
         await self.state_manager.update(task_id, {
             'job_retries': current_retries + 1,
-            'status': 'errored'
+            'status': 'errored',
+            'error': task.print_stack()
         })
 
         # Publish task data to delay queue
         await channel.publish(
-            task._job.data,
+            json.dumps(task._job.data),
             exchange_name=self.EXCHANGE,
             routing_key=self.QUEUE_DELAYED,
             properties={
@@ -231,35 +233,21 @@ class Worker:
             type_name='direct',
             durable=True)
 
-        # Errored tasks will remain a limited period of time
-        await channel.queue_declare(
-            queue_name=self.QUEUE_ERRORED, durable=True,
-            arguments={
-                'x-message-ttl': self.TTL_ERRORED,
-            })
+        # Declare errored queue
+        await self.queue_errored(channel, passive=False)
 
-        # Automatically move NACK tasks to errored queue
-        await channel.queue_declare(
-            queue_name=self.QUEUE_MAIN, durable=True,
-            arguments={
-                'x-dead-letter-exchange': self.EXCHANGE,
-                'x-dead-letter-routing-key': self.QUEUE_ERRORED,
-            })
+        # Declare main queue
+        await self.queue_main(channel, passive=False)
+
         await channel.queue_bind(
             exchange_name=self.EXCHANGE,
             queue_name=self.QUEUE_MAIN,
             routing_key=self.QUEUE_MAIN,
         )
 
-        # Declare delayed queue: set TTL to move taks from delayed
-        # queue to main queue
-        await channel.queue_declare(
-            queue_name=self.QUEUE_DELAYED, durable=True,
-            arguments={
-                'x-message-ttl': self.TTL_DELAYED,
-                'x-dead-letter-exchange': self.EXCHANGE,
-                'x-dead-letter-routing-key': self.QUEUE_MAIN,
-            })
+        # Declare delayed queue
+        await self.queue_delayed(channel, passive=False)
+
         await channel.queue_bind(
             exchange_name=self.EXCHANGE,
             queue_name=self.QUEUE_DELAYED,
@@ -278,6 +266,38 @@ class Worker:
         asyncio.ensure_future(self.update_status())
 
         logger.warning(f"Subscribed to queue: {self.QUEUE_MAIN}")
+
+    async def queue_main(self, channel, passive=True):
+        # Main queue
+        # Automatically move NACK tasks to errored queue
+        return await channel.queue_declare(
+            queue_name=self.QUEUE_MAIN, durable=True,
+            passive=passive,
+            arguments={
+                'x-dead-letter-exchange': self.EXCHANGE,
+                'x-dead-letter-routing-key': self.QUEUE_ERRORED,
+            })
+
+    async def queue_delayed(self, channel, passive=True):
+        # Declare delayed queue: set TTL to move taks from delayed
+        # queue to main queue
+        return await channel.queue_declare(
+            queue_name=self.QUEUE_DELAYED, durable=True,
+            passive=passive,
+            arguments={
+                'x-dead-letter-exchange': self.EXCHANGE,
+                'x-dead-letter-routing-key': self.QUEUE_MAIN,
+                'x-message-ttl': self.TTL_DELAYED,
+            })
+
+    async def queue_errored(self, channel, passive=True):
+        # Errored tasks will remain a limited period of time
+        return await channel.queue_declare(
+            queue_name=self.QUEUE_ERRORED, durable=True,
+            passive=passive,
+            arguments={
+                'x-message-ttl': self.TTL_ERRORED,
+            })
 
     def cancel(self):
         """

--- a/guillotina_amqp/worker.py
+++ b/guillotina_amqp/worker.py
@@ -1,3 +1,9 @@
+"""
+NOTE:
+ - Task: used to refer to an asyncio task
+ - Job: used to refer a specification of some work that has to be done
+"""
+
 from guillotina import app_settings
 from guillotina_amqp import amqp
 from guillotina_amqp.job import Job
@@ -13,6 +19,14 @@ logger = logging.getLogger('guillotina_amqp')
 
 
 class Worker:
+    """Workers hold an asyncio loop in which will run several tasks. It
+    reads from RabbitMQ for new job descriptions and will run them in
+    asyncio tasks.
+
+    The worker is aware of a state manager in which he posts job
+    results.
+
+    """
     sleep_interval = 0.05
     last_activity = time.time()
     total_run = 0
@@ -34,31 +48,44 @@ class Worker:
 
     @property
     def num_running(self):
+        """Returns the number of currently running jobs"""
         return len(self._running)
 
     async def handle_queued_job(self, channel, body, envelope, properties):
+        """Callback triggered when there is a new job in the job channel (e.g:
+        a new task in a rabbitmq queue)
+
+        """
+        # Deserialize job description
         if not isinstance(body, str):
             body = body.decode('utf-8')
         data = json.loads(body)
+
+        # Set status to scheduled
         task_id = data['task_id']
         dotted_name = data['func']
         await self.state_manager.update(task_id, {
             'status': 'scheduled'
         })
         logger.info(f'Received task: {task_id}: {dotted_name}')
+
+        # Block if we reached maximum number of running tasks
         while len(self._running) >= self._max_size:
             await asyncio.sleep(self.sleep_interval)
             self.last_activity = time.time()
+
+        # Create job object
         self.last_activity = time.time()
         job = Job(self.request, data, channel, envelope)
 
+        # Get the redis lock on the task so no other worker takes it
         _id = job.data['task_id']
         ts = TaskState(_id)
         res = await ts.acquire(timeout=120)
         if not res:
             raise Exception()
 
-
+        # Add the task to the loop and start it
         task = self.loop.create_task(job())
         task._job = job
         job.task = task
@@ -66,10 +93,15 @@ class Worker:
         task.add_done_callback(self._done_callback)
 
     def _done_callback(self, task):
+        """This is called when a job finishes execution"""
         self._done.append(task)
         self.total_run += 1
 
     async def start(self):
+        """Called on worker startup. Connects to the rabbitmq. Declares and
+        configures the different queues.
+
+        """
         channel, transport, protocol = await amqp.get_connection()
 
         await channel.exchange_declare(
@@ -77,11 +109,14 @@ class Worker:
             type_name='direct',
             durable=True)
 
+        # Errored tasks will remain a limited period of time
         await channel.queue_declare(
             queue_name=app_settings['amqp']['queue'] + '-error', durable=True,
             arguments={
-                'x-message-ttl': 1000 * 60 * 60 * 24 * 7
+                'x-message-ttl': 1000 * 60 * 60 * 24 * 7  # 1 week
             })
+
+        # Automatically move failed tasks to errored queue
         await channel.queue_declare(
             queue_name=app_settings['amqp']['queue'], durable=True,
             arguments={
@@ -94,19 +129,28 @@ class Worker:
             routing_key=app_settings['amqp']['queue'])
 
         await channel.basic_qos(prefetch_count=4)
+
+        # Configure consume callback
         await channel.basic_consume(
             self.handle_queued_job,
             queue_name=app_settings['amqp']['queue'])
 
+        # Start task that will update status periodically
         asyncio.ensure_future(self.update_status())
 
         logger.warning(f"Subscribed to queue: {app_settings['amqp']['queue']}")
 
     def cancel(self):
+        """
+        Cancels the worker (i.e: all its running tasks)
+        """
         for task in self._running:
             task.cancel()
 
     async def join(self):
+        """
+        Waits for all tasks to finish
+        """
         while len(self._running) > 0:
             await asyncio.sleep(0.01)
 
@@ -114,20 +158,30 @@ class Worker:
         return True
 
     async def update_status(self):
+        """Updates status for running tasks and kills running tasks that have
+        been canceled.
+
+        """
         while True:
             await asyncio.sleep(20)
             for task in self._running:
                 _id = task._job.data['task_id']
                 ts = TaskState(_id)
+
                 if task in self._done:
+                    # Clean-up running task list and release lock in
+                    # StateManager
                     self._running.remove(task)
                     await ts.release()
                 else:
+                    # Get StateManager lock
                     result = await ts.acquire()
                     if not result:
                         # kill the task
                         task.cancel()
 
+            # Cancel local tasks that have been cancelled in global
+            # state manager
             async for val in self.state_manager.cancelation_list():
                 for task in self._running:
                     _id = task._job.data['task_id']

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
             'pytest-aiohttp',
             'pytest-cov',
             'coverage==4.4',
-            'pytest_docker_fixtures==1.2.3',
+            'pytest_docker_fixtures[rabbitmq]==1.2.5',
         ]
     },
     license='BSD',

--- a/setup.py
+++ b/setup.py
@@ -13,10 +13,10 @@ setup(
     description='Integrate amqp into guillotina',
     long_description=README,
     install_requires=[
-        'guillotina>=3.0.0,<4.0.0',
+        'guillotina>=4.0.0',
         'aioamqp',
         'lru-dict',
-        'guillotina_rediscache==1.3.4',
+        'guillotina_rediscache==2.0.4',
     ],
     author='Nathan Van Gheem',
     author_email='vangheem@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,10 @@ setup(
     description='Integrate amqp into guillotina',
     long_description=README,
     install_requires=[
-        'guillotina>=2.1.5',
+        'guillotina>=3.0.0,<4.0.0',
         'aioamqp',
-        'lru-dict'
+        'lru-dict',
+        'guillotina_rediscache==1.3.4',
     ],
     author='Nathan Van Gheem',
     author_email='vangheem@gmail.com',
@@ -34,7 +35,8 @@ setup(
             'pytest-asyncio>=0.8.0',
             'pytest-aiohttp',
             'pytest-cov',
-            'coverage==4.0.3'
+            'coverage==4.4',
+            'pytest_docker_fixtures==1.2.3',
         ]
     },
     license='BSD',


### PR DESCRIPTION
Done so far:
 - [x] Added docstrings and API swagger annotations
 - [x] Configured a new delayed queue
 - [x] Implemented memory state manager
 - [x] Added tests for state managers (both redis and memory)
 - [x] Added test for task cancelation
 - [x] Added utility to cancel tasks
 - [x] Added tests for the api endpoints
 - [x] Implement mechanism to refresh locks in MemoryStateManager (similar to what redis does)
 - [x] Store task payload in data, otherwise that's lost!
 - [x] Worker: check that a task is not canceled before running it
 - [x] Implement methods on the StateManager to check whether a task_id is in a `canceled` or `running` sets
 - [x] Implement worker retrials using delayed queue
 - [x] Add owner checks for task cancelation, lock refresh and release (otherwise workers could cancel each other's tasks)  
 - [ ] Properly configure rabbitmq and worker timeouts
 - [x] Test worker publishes to delay queue on failure
 - [x] Test worker NACKs after max retries reached
 - [x] Test worker ACKs if task ran correctly
 - [ ] Allow job to update status from within the function that is ran
 - [x] Update to guillotina 4