### PR TITLE
Fix task cancelation and unit tests

### DIFF
--- a/guillotina_amqp/state.py
+++ b/guillotina_amqp/state.py
@@ -22,7 +22,7 @@ except ImportError:
     aioredis = None
 
 
-logger = logging.getLogger('guillotina_amqp')
+logger = logging.getLogger('guillotina_amqp.state')
 
 DEFAULT_LOCK_TTL_S = 120
 
@@ -238,7 +238,7 @@ class TaskState:
             data = await util.get(self.task_id)
             if not data:
                 raise TaskNotFoundException(self.task_id)
-            if data.get('status') in ('finished', 'errored'):
+            if data.get('status') in ('finished', 'errored', 'canceled'):
                 return data
             await asyncio.sleep(wait)
 
@@ -254,6 +254,7 @@ class TaskState:
         possible statuses:
         - scheduled
         - consumed
+        - canceled
         - running
         - finished
         - errored

--- a/guillotina_amqp/tests/__init__.py
+++ b/guillotina_amqp/tests/__init__.py
@@ -1,0 +1,7 @@
+import logging
+from guillotina_amqp.job import logger as logger_job
+from guillotina_amqp.worker import logger as logger_worker
+
+logging.basicConfig()
+logger_job.setLevel(10)
+logger_worker.setLevel(10)

--- a/guillotina_amqp/tests/fixtures.py
+++ b/guillotina_amqp/tests/fixtures.py
@@ -1,6 +1,7 @@
 from guillotina import testing
 import pytest
 from guillotina_amqp.worker import Worker
+from guillotina_amqp import amqp
 from guillotina import app_settings
 
 
@@ -76,3 +77,9 @@ def redis_enabled(redis, dummy_request):
 def redis_disabled(dummy_request):
     app_settings['amqp']['persistent_manager'] = 'memory'
     yield
+
+
+@pytest.fixture('function')
+async def amqp_queues(dummy_request):
+    channel, transport, protocol = await amqp.get_connection()
+    return protocol.queues

--- a/guillotina_amqp/utils.py
+++ b/guillotina_amqp/utils.py
@@ -19,7 +19,7 @@ import threading
 import asyncio
 
 
-logger = logging.getLogger('guillotina_amqp')
+logger = logging.getLogger('guillotina_amqp.utils')
 
 
 async def cancel_task(task_id):


### PR DESCRIPTION
Task exceptions handling is now done outside of Job, in the Worker._task_callback coroutine