### PR TITLE
Allow job functions to be async generators

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,7 @@ script:
   - pytest -s --cov=guillotina_amqp -s --tb=native -v --cov-report term-missing --cov-append guillotina_amqp
 after_success:
   - codecov
+services:
+  - redis-server
+  - rabbitmq
+  - docker

--- a/guillotina_amqp/amqp.py
+++ b/guillotina_amqp/amqp.py
@@ -45,7 +45,7 @@ async def handle_connection_closed(name, protocol):
             return
         # we just remove so next time get_connection is retrieved, a new
         # connection is retrieved.
-        logger.warn('Disconnect detected with rabbitmq connection, forcing reconnect')
+        logger.warning('Disconnect detected with rabbitmq connection, forcing reconnect')
         await remove_connection(name)
     except Exception:
         logger.error('Error waiting for connection to close', exc_info=True)

--- a/guillotina_amqp/tests/fixtures.py
+++ b/guillotina_amqp/tests/fixtures.py
@@ -33,7 +33,7 @@ testing.configure_with(base_settings_configurator)
 
 
 @pytest.fixture('function')
-def amqp_worker(loop):
+def amqp_worker(loop, rabbitmq_container):
     # Create worker
     _worker = Worker(loop=loop)
     _worker.update_status_interval = 2
@@ -79,8 +79,24 @@ def configured_state_manager(request, redis, dummy_request, loop):
         print('Running with memory')
         yield
 
-        
+
 @pytest.fixture('function')
-async def amqp_queues(dummy_request):
+async def amqp_channel():
     channel, transport, protocol = await amqp.get_connection()
-    return protocol.queues
+    return channel
+
+
+@pytest.fixture('function')
+def rabbitmq_container(rabbitmq):
+    app_settings['amqp'] = {
+        "connection_factory": "aioamqp.connect",
+        "host": rabbitmq[0],
+        "port": rabbitmq[1],
+        "login": "guest",
+        "password": "guest",
+        "vhost": "/",
+        "heartbeat": 800,
+        "exchange": "guillotina",
+        "queue": "guillotina",
+        "persistent_manager": "memory"
+    }

--- a/guillotina_amqp/tests/utils.py
+++ b/guillotina_amqp/tests/utils.py
@@ -6,6 +6,24 @@ async def _test_func(one, two, one_keyword=None):
     return one + two
 
 
+async def _test_asyncgen(one, two, one_keyword=None):
+    yield (1, 'Starting task')
+    yield (1, 'Yellow')
+    yield (0, one + two)
+
+
+async def _test_asyncgen_invalid():
+    yield (1, 1, 2, 3)
+    yield (0)
+
+
+async def _test_asyncgen_doubley(arg1, arg2, arg3):
+    yield (0, arg1)
+    yield (0, arg2)
+    yield (1, 'OK')
+    yield (0, arg3)
+
+
 @task
 async def _test_long_func(duration):
     print('Started task')

--- a/guillotina_amqp/worker.py
+++ b/guillotina_amqp/worker.py
@@ -80,7 +80,8 @@ class Worker:
         task_id = data['task_id']
         dotted_name = data['func']
         await self.state_manager.update(task_id, {
-            'status': 'scheduled'
+            'status': 'scheduled',
+            'eventlog': {},
         })
         logger.info(f'Received task: {task_id}: {dotted_name}')
 
@@ -145,7 +146,7 @@ class Worker:
         # Update status to errored with the traceback
         await self.state_manager.update(task_id, {
             'status': 'errored',
-            'errors': task.print_stack(),
+            'error': task.print_stack(),
         })
 
     async def _handle_retry(self, task, current_retries):
@@ -155,12 +156,13 @@ class Worker:
         # Increment retry count
         await self.state_manager.update(task_id, {
             'job_retries': current_retries + 1,
-            'status': 'errored'
+            'status': 'errored',
+            'error': task.print_stack()
         })
 
         # Publish task data to delay queue
         await channel.publish(
-            task._job.data,
+            json.dumps(task._job.data),
             exchange_name=self.EXCHANGE,
             routing_key=self.QUEUE_DELAYED,
             properties={
@@ -231,35 +233,21 @@ class Worker:
             type_name='direct',
             durable=True)
 
-        # Errored tasks will remain a limited period of time
-        await channel.queue_declare(
-            queue_name=self.QUEUE_ERRORED, durable=True,
-            arguments={
-                'x-message-ttl': self.TTL_ERRORED,
-            })
+        # Declare errored queue
+        await self.queue_errored(channel, passive=False)
 
-        # Automatically move NACK tasks to errored queue
-        await channel.queue_declare(
-            queue_name=self.QUEUE_MAIN, durable=True,
-            arguments={
-                'x-dead-letter-exchange': self.EXCHANGE,
-                'x-dead-letter-routing-key': self.QUEUE_ERRORED,
-            })
+        # Declare main queue
+        await self.queue_main(channel, passive=False)
+
         await channel.queue_bind(
             exchange_name=self.EXCHANGE,
             queue_name=self.QUEUE_MAIN,
             routing_key=self.QUEUE_MAIN,
         )
 
-        # Declare delayed queue: set TTL to move taks from delayed
-        # queue to main queue
-        await channel.queue_declare(
-            queue_name=self.QUEUE_DELAYED, durable=True,
-            arguments={
-                'x-message-ttl': self.TTL_DELAYED,
-                'x-dead-letter-exchange': self.EXCHANGE,
-                'x-dead-letter-routing-key': self.QUEUE_MAIN,
-            })
+        # Declare delayed queue
+        await self.queue_delayed(channel, passive=False)
+
         await channel.queue_bind(
             exchange_name=self.EXCHANGE,
             queue_name=self.QUEUE_DELAYED,
@@ -278,6 +266,38 @@ class Worker:
         asyncio.ensure_future(self.update_status())
 
         logger.warning(f"Subscribed to queue: {self.QUEUE_MAIN}")
+
+    async def queue_main(self, channel, passive=True):
+        # Main queue
+        # Automatically move NACK tasks to errored queue
+        return await channel.queue_declare(
+            queue_name=self.QUEUE_MAIN, durable=True,
+            passive=passive,
+            arguments={
+                'x-dead-letter-exchange': self.EXCHANGE,
+                'x-dead-letter-routing-key': self.QUEUE_ERRORED,
+            })
+
+    async def queue_delayed(self, channel, passive=True):
+        # Declare delayed queue: set TTL to move taks from delayed
+        # queue to main queue
+        return await channel.queue_declare(
+            queue_name=self.QUEUE_DELAYED, durable=True,
+            passive=passive,
+            arguments={
+                'x-dead-letter-exchange': self.EXCHANGE,
+                'x-dead-letter-routing-key': self.QUEUE_MAIN,
+                'x-message-ttl': self.TTL_DELAYED,
+            })
+
+    async def queue_errored(self, channel, passive=True):
+        # Errored tasks will remain a limited period of time
+        return await channel.queue_declare(
+            queue_name=self.QUEUE_ERRORED, durable=True,
+            passive=passive,
+            arguments={
+                'x-message-ttl': self.TTL_ERRORED,
+            })
 
     def cancel(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
             'pytest-aiohttp',
             'pytest-cov',
             'coverage==4.4',
-            'pytest_docker_fixtures==1.2.3',
+            'pytest_docker_fixtures[rabbitmq]==1.2.5',
         ]
     },
     license='BSD',


### PR DESCRIPTION
With these changes the job function/coroutine can be an async
generator that yields intermediary messages.

Add unit tests for async generator jobs.
Add redis and rabbitmq services in .travis.yml

Use new rabbitmq docker fixture from pytest-docker-fixtures

Use separate coroutines for queues declaration in the worker that
can be called from outside the worker.