### PR TITLE
Guillotina AMQP 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,92 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# IPython Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# dotenv
+.env
+
+# virtualenv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+
+# Rope project settings
+.ropeproject
+
+.DS_Store
+.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,7 @@ script:
   - pytest -s --cov=guillotina_amqp -s --tb=native -v --cov-report term-missing --cov-append guillotina_amqp
 after_success:
   - codecov
+services:
+  - redis-server
+  - rabbitmq
+  - docker

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,7 @@
-1.0.9 (unreleased)
-------------------
+2.0.0
+-----
+
+Major improvements:
 
  - Added task retrial using delay queue
  - Tasks are only ACKed if successful, otherwise are sent to delay queue

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,12 @@
 1.0.9 (unreleased)
 ------------------
 
-- Nothing changed yet.
+ - Added task retrial using delay queue
+ - Tasks are only ACKed if successful, otherwise are sent to delay queue
+ - Allow task cancelation
+ - Improved API
+ - Upgraded to guillotina 4
+ - Added plenty of tests for worker, amqp and state manager
 
 
 1.0.8 (2018-10-09)

--- a/guillotina_amqp/__init__.py
+++ b/guillotina_amqp/__init__.py
@@ -16,7 +16,7 @@ app_settings = {
         "heartbeat": 800,
         "exchange": "guillotina",
         "queue": "guillotina",
-        "persistent_manager": "dummy"
+        "persistent_manager": "memory"
     },
     'commands': {
         "amqp-worker": "guillotina_amqp.commands.worker.WorkerCommand"

--- a/guillotina_amqp/__init__.py
+++ b/guillotina_amqp/__init__.py
@@ -13,7 +13,7 @@ app_settings = {
         "login": "guest",
         "password": "guest",
         "vhost": "/",
-        "heartbeat": 800,
+        "heartbeat": 120,  # 2 minutes
         "exchange": "guillotina",
         "queue": "guillotina",
         "persistent_manager": "memory"

--- a/guillotina_amqp/amqp.py
+++ b/guillotina_amqp/amqp.py
@@ -45,7 +45,7 @@ async def handle_connection_closed(name, protocol):
             return
         # we just remove so next time get_connection is retrieved, a new
         # connection is retrieved.
-        logger.warn('Disconnect detected with rabbitmq connection, forcing reconnect')
+        logger.warning('Disconnect detected with rabbitmq connection, forcing reconnect')
         await remove_connection(name)
     except Exception:
         logger.error('Error waiting for connection to close', exc_info=True)

--- a/guillotina_amqp/amqp.py
+++ b/guillotina_amqp/amqp.py
@@ -89,11 +89,11 @@ async def connect(**kwargs):
     conn_factory = resolve_dotted_name(
         ampq_settings.get('connection_factory', aioamqp.connect))
     transport, protocol = await conn_factory(
-        host=ampq_settings['host'],
-        port=ampq_settings['port'],
-        login=ampq_settings['login'],
-        password=ampq_settings['password'],
-        virtualhost=ampq_settings['vhost'],
+        ampq_settings['host'],
+        ampq_settings['port'],
+        ampq_settings['login'],
+        ampq_settings['password'],
+        ampq_settings['vhost'],
         heartbeat=800,
         **kwargs
     )

--- a/guillotina_amqp/amqp.py
+++ b/guillotina_amqp/amqp.py
@@ -14,10 +14,10 @@ async def remove_connection(name='default'):
     Purpose here is to close out a bad connection.
     Next time get_connection is called, a new connection will be established
     '''
-    ampq_settings = app_settings['amqp']
-    if 'connections' not in ampq_settings:
-        ampq_settings['connections'] = {}
-    connections = ampq_settings['connections']
+    amqp_settings = app_settings['amqp']
+    if 'connections' not in amqp_settings:
+        amqp_settings['connections'] = {}
+    connections = amqp_settings['connections']
     if name not in connections:
         return
 
@@ -62,10 +62,10 @@ async def heartbeat():
 
 
 async def get_connection(name='default'):
-    ampq_settings = app_settings['amqp']
-    if 'connections' not in ampq_settings:
-        ampq_settings['connections'] = {}
-    connections = ampq_settings['connections']
+    amqp_settings = app_settings['amqp']
+    if 'connections' not in amqp_settings:
+        amqp_settings['connections'] = {}
+    connections = amqp_settings['connections']
     if name in connections:
         connection = connections[name]
         return connection['channel'], connection['transport'], connection['protocol']
@@ -76,25 +76,25 @@ async def get_connection(name='default'):
         'transport': transport
     }
     asyncio.ensure_future(handle_connection_closed(name, protocol))
-    if ampq_settings.get('heartbeat_task') is None:
+    if amqp_settings.get('heartbeat_task') is None:
         logger.info('Starting amqp heartbeat')
-        ampq_settings.update({
+        amqp_settings.update({
             'heartbeat_task': asyncio.ensure_future(heartbeat())
         })
     return channel, transport, protocol
 
 
 async def connect(**kwargs):
-    ampq_settings = app_settings['amqp']
+    amqp_settings = app_settings['amqp']
     conn_factory = resolve_dotted_name(
-        ampq_settings.get('connection_factory', aioamqp.connect))
+        amqp_settings.get('connection_factory', aioamqp.connect))
     transport, protocol = await conn_factory(
-        ampq_settings['host'],
-        ampq_settings['port'],
-        ampq_settings['login'],
-        ampq_settings['password'],
-        ampq_settings['vhost'],
-        heartbeat=800,
+        amqp_settings['host'],
+        amqp_settings['port'],
+        amqp_settings['login'],
+        amqp_settings['password'],
+        amqp_settings['vhost'],
+        heartbeat=amqp_settings['heartbeat'],
         **kwargs
     )
     channel = await protocol.channel()

--- a/guillotina_amqp/api.py
+++ b/guillotina_amqp/api.py
@@ -1,18 +1,87 @@
 from guillotina import configure
-from guillotina.interfaces import IApplication
+
+from guillotina.response import HTTPPreconditionFailed
 from guillotina.response import HTTPNotFound
-from guillotina_amqp.exceptions import TaskNotFoundException
-from guillotina_amqp.state import TaskState
+
+from .state import get_state_manager
+
+
+@configure.service(method='GET', name='@amqp-tasks',
+                   permission='guillotina.AccessContent',
+                   summary='Returns the list of running tasks')
+async def list_tasks(context, request):
+    mngr = get_state_manager()
+    ret = []
+    async for el in mngr.list():
+        ret.append(el)
+    return ret
 
 
 @configure.service(
-    context=IApplication, method='GET', permission='guillotina.Manage',
-    name='@task-status/{id}')
-async def get_task_data(context, request):
-    try:
-        task = TaskState(request.matchdict['id'])
-        return await task.get_state()
-    except TaskNotFoundException:
+    method='GET', name='@amqp-info',
+    permission='guillotina.AccessContent',
+    summary='Shows the info of a given task id',
+    parameters=[{
+        "name": "task_id",
+        "in": "query",
+        "required": True,
+        "type": "string",
+    }])
+async def info_task(context, request):
+    mngr = get_state_manager()
+
+    task_id = request.rel_url.query.get('task_id')
+    if not task_id:
+        raise HTTPPreconditionFailed(content={
+            'reason': 'Missing task_id'
+        })
+
+    data = await mngr.get(task_id)
+    if not data:
         raise HTTPNotFound(content={
             'reason': 'Task not found'
         })
+
+    return await mngr.get(task_id)
+
+
+@configure.service(
+    method='DELETE', name='@amqp-cancel',
+    permission='guillotina.AccessContent',
+    summary='Cancel a specific task by id',
+    parameters=[{
+        "name": "task_id",
+        "in": "query",
+        "required": True,
+        "type": "string",
+    }])
+async def cancel_task(context, request):
+    mngr = get_state_manager()
+
+    task_id = request.rel_url.query.get('task_id')
+    if not task_id:
+        raise HTTPPreconditionFailed(content={
+            'reason': 'Missing task_id'
+        })
+
+    if await mngr.is_canceled(task_id):
+        return {
+            'ok': True,
+            'info': 'already canceled'
+        }
+
+    if not await mngr.exists(task_id):
+        raise HTTPNotFound(content={
+            'reason': 'Task not found'
+        })
+
+    if await mngr.cancel(task_id):
+        return {
+            'ok': True,
+            'info': 'task canceled'
+        }
+
+    return {
+        'ok': False,
+        'info': 'could not cancel task'
+    }

--- a/guillotina_amqp/api.py
+++ b/guillotina_amqp/api.py
@@ -1,13 +1,12 @@
 from guillotina import configure
-
-from guillotina.response import HTTPPreconditionFailed
 from guillotina.response import HTTPNotFound
-
+from .state import TaskState
 from .state import get_state_manager
+from .exceptions import TaskNotFoundException
 
 
 @configure.service(method='GET', name='@amqp-tasks',
-                   permission='guillotina.AccessContent',
+                   permission='guillotina.Manage',
                    summary='Returns the list of running tasks')
 async def list_tasks(context, request):
     mngr = get_state_manager()
@@ -18,70 +17,28 @@ async def list_tasks(context, request):
 
 
 @configure.service(
-    method='GET', name='@amqp-info',
-    permission='guillotina.AccessContent',
-    summary='Shows the info of a given task id',
-    parameters=[{
-        "name": "task_id",
-        "in": "query",
-        "required": True,
-        "type": "string",
-    }])
+    method='GET', name='@amqp-info/{task_id}',
+    permission='guillotina.Manage',
+    summary='Shows the info of a given task id')
 async def info_task(context, request):
-    mngr = get_state_manager()
-
-    task_id = request.rel_url.query.get('task_id')
-    if not task_id:
-        raise HTTPPreconditionFailed(content={
-            'reason': 'Missing task_id'
-        })
-
-    data = await mngr.get(task_id)
-    if not data:
+    try:
+        task = TaskState(request.matchdict['task_id'])
+        return await task.get_state()
+    except TaskNotFoundException:
         raise HTTPNotFound(content={
             'reason': 'Task not found'
         })
-
-    return await mngr.get(task_id)
 
 
 @configure.service(
-    method='DELETE', name='@amqp-cancel',
-    permission='guillotina.AccessContent',
-    summary='Cancel a specific task by id',
-    parameters=[{
-        "name": "task_id",
-        "in": "query",
-        "required": True,
-        "type": "string",
-    }])
+    method='DELETE', name='@amqp-cancel/{task_id}',
+    permission='guillotina.Manage',
+    summary='Cancel a specific task by id')
 async def cancel_task(context, request):
-    mngr = get_state_manager()
-
-    task_id = request.rel_url.query.get('task_id')
-    if not task_id:
-        raise HTTPPreconditionFailed(content={
-            'reason': 'Missing task_id'
-        })
-
-    if await mngr.is_canceled(task_id):
-        return {
-            'ok': True,
-            'info': 'already canceled'
-        }
-
-    if not await mngr.exists(task_id):
+    task = TaskState(request.matchdict['task_id'])
+    try:
+        return await task.cancel()
+    except TaskNotFoundException:
         raise HTTPNotFound(content={
             'reason': 'Task not found'
         })
-
-    if await mngr.cancel(task_id):
-        return {
-            'ok': True,
-            'info': 'task canceled'
-        }
-
-    return {
-        'ok': False,
-        'info': 'could not cancel task'
-    }

--- a/guillotina_amqp/commands/worker.py
+++ b/guillotina_amqp/commands/worker.py
@@ -6,18 +6,39 @@ import asyncio
 import logging
 import sys
 import time
+import threading
+import os
 
 
 logger = logging.getLogger('guillotina_amqp')
+logging.basicConfig(level=logging.INFO)
+
+class EventLoopWatchdog(threading.Thread):
+    def __init__(self, loop, timeout):
+        super().__init__()
+        self.loop = loop
+        self.timeout = timeout * 60  # In seconds
+        self._time = loop.time()
+
+    def check(self):
+        _old_time, self._time = self._time, self.loop.time()
+        diff = self._time - _old_time
+        if diff > self.timeout:
+            logger.error(f'Exiting worker because no activity in {diff} seconds')
+            os._exit(1)
+        else:
+            threading.Timer(self.timeout/2, self.check).start()
+
+    def run(self):
+        threading.Timer(10, self.check).start()
 
 
-async def activity_check(worker, timeout):
+# This method just to trigger a context switching in the event loop in
+# case nothing is running. Most likely is not even needed since RMQ/Redis
+# drivers also are running in the same loop.
+async def probe(timeout):
     while True:
-        await asyncio.sleep(60)
-        if (time.time() - worker.last_activity) > timeout:
-            logger.error(f'Exiting worker because no activity in {timeout} seconds')
-            sys.exit(1)
-
+        await asyncio.sleep(timeout)
 
 class WorkerCommand(Command):
     description = 'AMQP worker'
@@ -34,7 +55,11 @@ class WorkerCommand(Command):
         worker = Worker(self.request, self.get_loop())
         await worker.start()
         if arguments.auto_kill_timeout > 0:
-            asyncio.ensure_future(activity_check(worker, arguments.auto_kill_timeout))
+            timeout = arguments.auto_kill_timeout
+            self.get_loop().create_task(probe(timeout/2))
+            t = EventLoopWatchdog(self.get_loop(), timeout)
+            t.start()
+
         while True:
             # make this run forever...
             await asyncio.sleep(999999)

--- a/guillotina_amqp/commands/worker.py
+++ b/guillotina_amqp/commands/worker.py
@@ -4,36 +4,49 @@ from guillotina_amqp.worker import Worker
 import aiotask_context
 import asyncio
 import logging
-import sys
-import time
 import threading
 import os
 
 
 logger = logging.getLogger('guillotina_amqp')
 
+
 class EventLoopWatchdog(threading.Thread):
+    """Takes care of exiting worker after specified loop no-activity
+    timeout for the worker loop.
+
+    This prevents a task from taking over the asynio loop forever and
+    preventing other tasks to run.
+
+    If a task hangs, the watchdog will exit the worker and unfinished jobs
+    will be taken by other workers.
+    """
     def __init__(self, loop, timeout):
         super().__init__()
         self.loop = loop
         self.timeout = timeout * 60  # In seconds
+        # Start time
         self._time = loop.time()
 
     def check(self):
+        # Elapsed time since last update
         diff = self.loop.time() - self._time
 
         if diff > self.timeout:
             logger.error(f'Exiting worker because no activity in {diff} seconds')
             os._exit(1)
         else:
+            # Schedule a check again
             threading.Timer(self.timeout/4, self.check).start()
             logger.debug(f'Last refreshed watchdog was {diff}s. ago')
 
-    # This method just to trigger a context switching in the event loop in
-    # and sense the delta between the ideal timeout (10s)
     async def probe(self):
+        """This method is used to trigger a context switching in the event
+        loop and measure elapsed time between runs (10s)
+        """
         while True:
             await asyncio.sleep(10)
+            # Update the watchdog time
             self._time = self.loop.time()
 
     def run(self):
@@ -42,6 +55,7 @@ class EventLoopWatchdog(threading.Thread):
 
 
 class WorkerCommand(Command):
+    """Guillotina command to start a worker"""
     description = 'AMQP worker'
 
     def get_parser(self):
@@ -52,10 +66,13 @@ class WorkerCommand(Command):
         return parser
 
     async def run(self, arguments, settings, app):
-        timeout = arguments.auto_kill_timeout
         aiotask_context.set('request', self.request)
+
+        # Run the actual worker in the same loop
         worker = Worker(self.request, self.get_loop())
         await worker.start()
+
+        timeout = arguments.auto_kill_timeout
         if timeout > 0:
             # We need to run this outside the main loop and the current thread
             thread = EventLoopWatchdog(self.get_loop(), timeout)

--- a/guillotina_amqp/exceptions.py
+++ b/guillotina_amqp/exceptions.py
@@ -1,8 +1,22 @@
-
-
 class TaskNotFinishedException(Exception):
     pass
 
 
 class TaskNotFoundException(Exception):
+    pass
+
+
+class TaskAlreadyAcquired(Exception):
+    pass
+
+
+class TaskAlreadyCanceled(Exception):
+    pass
+
+
+class TaskAccessUnauthorized(Exception):
+    pass
+
+
+class TaskMaxRetriesReached(Exception):
     pass

--- a/guillotina_amqp/interfaces.py
+++ b/guillotina_amqp/interfaces.py
@@ -4,19 +4,73 @@ from zope.interface import Interface
 
 class IStateManagerUtility(Interface):
     async def update(task_id, data):
-        pass
+        """Updates data related to task id into state manager
+        """
+        raise NotImplementedError()
 
     async def get(self, task_id):
-        pass
+        """Gets whatever was stored in state manager for task_id
+        """
+        raise NotImplementedError()
+
+    async def exists(self, task_id):
+        """Returns whether a task id exists in the state manager
+        """
+        raise NotImplementedError()
 
     async def list(self):
-        if False: yield
+        """
+        Yields items from the list of stored items
+        """
+        raise NotImplementedError()
 
-    async def lock(self, task_id, timeout=None, ttl=None):
-        pass
+    async def is_mine(self, task_id):
+        """Returns whether the worker has a lock on a given task_idq
+        """
+        raise NotImplementedError()
 
-    async def unlock(self, task_id):
-        pass
+    async def cancel(self, task_id):
+        """
+        Sets task_id to the canceled set of tasks
+        """
+        raise NotImplementedError()
+
+    async def acquire(self, task_id, ttl):
+        """
+        Get a lock on a certain task, by id.
+        """
+        raise NotImplementedError()
+
+    async def release(self, task_id):
+        """
+        Release the lock for the specified task
+        """
+        raise NotImplementedError()
+
+    async def refresh_lock(self, task_id, ttl):
+        """
+        Update lock TTL
+        """
+        raise NotImplementedError()
+
+    async def cancelation_list(self):
+        """
+        Yields items from the canceled set
+        """
+        raise NotImplementedError()
+
+    async def clean_canceled(self, task_id):
+        """
+        Removes a task from the canceled set
+        """
+        raise NotImplementedError()
+
+    async def is_canceled(self, task_id):
+        """
+        Whether a task id has been cancelled
+        """
+        raise NotImplementedError()
+
 
 class ITaskDefinition(Interface):
     func = Attribute('actual function to run')

--- a/guillotina_amqp/interfaces.py
+++ b/guillotina_amqp/interfaces.py
@@ -6,6 +6,17 @@ class IStateManagerUtility(Interface):
     async def update(task_id, data):
         pass
 
+    async def get(self, task_id):
+        pass
+
+    async def list(self):
+        if False: yield
+
+    async def lock(self, task_id, timeout=None, ttl=None):
+        pass
+
+    async def unlock(self, task_id):
+        pass
 
 class ITaskDefinition(Interface):
     func = Attribute('actual function to run')

--- a/guillotina_amqp/job.py
+++ b/guillotina_amqp/job.py
@@ -27,7 +27,6 @@ import time
 import traceback
 import yarl
 import asyncio
-from datetime import datetime
 
 
 logger = logging.getLogger('guillotina_amqp.job')

--- a/guillotina_amqp/state.py
+++ b/guillotina_amqp/state.py
@@ -25,7 +25,7 @@ except ImportError:
 
 logger = logging.getLogger('guillotina_amqp.state')
 
-DEFAULT_LOCK_TTL_S = 120
+DEFAULT_LOCK_TTL_S = 60 * 1  # 1 minute
 
 
 @configure.utility(provides=IStateManagerUtility, name='memory')

--- a/guillotina_amqp/state.py
+++ b/guillotina_amqp/state.py
@@ -343,6 +343,12 @@ class TaskState:
 
     async def cancel(self):
         util = get_state_manager()
+        if await util.is_canceled(self.task_id):
+            # Already canceled
+            return True
+        if not await util.exists(self.task_id):
+            raise TaskNotFoundException
+        # Cancel it
         return await util.cancel(self.task_id)
 
     async def acquire(self, ttl=DEFAULT_LOCK_TTL_S):

--- a/guillotina_amqp/state.py
+++ b/guillotina_amqp/state.py
@@ -116,8 +116,8 @@ class RedisStateManager:
         # Exception is raised if no cache is found
         cache = await self.get_cache()
 
-        async for key in await cache.iscan(f'{self._cache_prefix}*'):
-            yield key
+        async for key in cache.iscan(match=f'{self._cache_prefix}*'):
+            yield key.decode()
 
     async def adquire(self, task_id, ttl=None):
         cache = await self.get_cache()

--- a/guillotina_amqp/state.py
+++ b/guillotina_amqp/state.py
@@ -3,16 +3,18 @@ from guillotina import configure
 from guillotina.component import get_utility
 from guillotina_amqp.exceptions import TaskNotFinishedException
 from guillotina_amqp.exceptions import TaskNotFoundException
+from guillotina_amqp.exceptions import TaskAlreadyAcquired
+from guillotina_amqp.exceptions import TaskAccessUnauthorized
+
 from guillotina_amqp.interfaces import IStateManagerUtility
 from lru import LRU
-from zope.interface.interfaces import ComponentLookupError
 
 import asyncio
 import json
 import logging
 import time
 import uuid
-
+import copy
 
 try:
     import aioredis
@@ -21,17 +23,9 @@ except ImportError:
     aioredis = None
 
 
-logger = logging.getLogger('guillotina_amqp')
+logger = logging.getLogger('guillotina_amqp.state')
 
-
-@configure.utility(provides=IStateManagerUtility, name='dummy')
-class DummyStateManager:
-
-    async def update(self, task_id, data):
-        pass
-
-    async def get(self, task_id):
-        pass
+DEFAULT_LOCK_TTL_S = 120
 
 
 @configure.utility(provides=IStateManagerUtility, name='memory')
@@ -39,44 +33,140 @@ class MemoryStateManager:
     '''
     Meaningless for anyting other than tests
     '''
+    def __init__(self, size=10):
+        self.size = size
+        self._data = LRU(self.size)
+        self._locks = {}
+        self._canceled = set()
+        self.worker_id = uuid.uuid4().hex
 
-    def __init__(self, size=5):
-        self._data = LRU(size)
+    def set_loop(self, loop=None):
+        pass
 
     async def update(self, task_id, data):
-        if task_id not in self._data:
-            self._data[task_id] = data
-        else:
-            self._data[task_id].update(data)
+        # Updates existing data with new data
+        existing = await self.get(task_id)
+        existing.update(data)
+        self._data[task_id] = existing
 
     async def get(self, task_id):
-        if task_id in self._data:
-            return self._data[task_id]
+        return self._data.get(task_id, {})
+
+    async def exists(self, task_id):
+        return task_id in self._data
+
+    async def list(self):
+        for task_id in self._data.keys():
+            yield task_id
+
+    async def acquire(self, task_id, ttl):
+        already_locked = await self.is_locked(task_id)
+        if already_locked:
+            raise TaskAlreadyAcquired(task_id)
+
+        # Set new lock
+        from guillotina_amqp.utils import TimeoutLock
+        lock = TimeoutLock(self.worker_id)
+        lock.acquire(ttl=ttl)
+        self._locks[task_id] = lock
+
+    async def is_mine(self, task_id):
+        if task_id not in self._locks:
+            raise TaskNotFoundException(task_id)
+        lock = self._locks[task_id]
+        return lock.locked() and lock.worker_id == self.worker_id
+
+    async def is_locked(self, task_id):
+        if task_id not in self._locks:
+            return False
+        return self._locks[task_id].locked()
+
+    async def release(self, task_id):
+        if not await self.is_mine(task_id):
+            # You can't refresh a lock that's not yours
+            raise TaskAccessUnauthorized(task_id)
+        # Release lock and pop it from data structure
+        self._locks[task_id].release()
+        self._locks.pop(task_id, None)
+
+    async def refresh_lock(self, task_id, ttl):
+        if task_id not in self._locks:
+            raise TaskNotFoundException(task_id)
+
+        if not await self.is_locked(task_id):
+            raise Exception(f'Task {task_id} is not locked')
+
+        if not await self.is_mine(task_id):
+            # You can't refresh a lock that's not yours
+            raise TaskAccessUnauthorized(task_id)
+
+        # Refresh
+        return self._locks[task_id].refresh_lock(ttl)
+
+    async def cancel(self, task_id):
+        self._canceled.update({task_id})
+        return True
+
+    async def cancelation_list(self):
+        canceled = copy.deepcopy(self._canceled)
+        for task_id in canceled:
+            yield task_id
+
+    async def clean_canceled(self, task_id):
+        try:
+            self._canceled.remove(task_id)
+            return True
+        except KeyError:
+            # Task id wasn't canceled
+            return False
+
+    async def is_canceled(self, task_id):
+        return task_id in self._canceled
+
+    async def _clean(self):
+        self._data = LRU(self.size)
+        self._locks = {}
+        self._canceled = set()
 
 
 _EMPTY = object()
 
 
-def get_state_manager():
-    try:
-        return get_utility(
-            IStateManagerUtility,
-            name=app_settings['amqp'].get('persistent_manager', 'dummy'))
-    except ComponentLookupError:
-        from guillotina_amqp.state import DummyStateManager
-        return DummyStateManager()
+def get_state_manager(loop=None):
+    """Factory that gets the configured state manager.
+
+    Currently we have two implementations: memory | redis
+    """
+    utility = get_utility(
+        IStateManagerUtility,
+        name=app_settings['amqp']['persistent_manager'],
+    )
+    if loop:
+        utility.set_loop(loop)
+    return utility
 
 
 @configure.utility(provides=IStateManagerUtility, name='redis')
 class RedisStateManager:
+    '''Implementation of the IStateManagerUtility with Redis
     '''
-    Meaningless for anyting other than tests
-    '''
-    _cache_prefix = 'amqpjobs-'
 
-    def __init__(self):
+    def __init__(self, loop=None):
+        self._cache_prefix = app_settings.get('redis_prefix_key', 'amqpjobs-')
+        self.loop = loop
         self._cache = None
         self.worker_id = uuid.uuid4().hex
+
+    def lock_prefix(self, task_id):
+        return f'{self._cache_prefix}lock:{task_id}'
+
+    @property
+    def cancel_prefix(self):
+        return f'{self._cache_prefix}cancel'
+
+    def set_loop(self, loop=None):
+        if loop:
+            self.loop = loop
 
     async def get_cache(self):
         if self._cache == _EMPTY:
@@ -88,7 +178,7 @@ class RedisStateManager:
             return None
 
         if 'redis' in app_settings:
-            self._cache = aioredis.Redis(await get_redis_pool())
+            self._cache = aioredis.Redis(await get_redis_pool(loop=self.loop))
             return self._cache
         else:
             self._cache = _EMPTY
@@ -100,10 +190,11 @@ class RedisStateManager:
             value = data
             existing = await cache.get(self._cache_prefix + task_id)
             if existing:
+                # Update existing with new data
                 value = json.loads(existing)
                 value.update(data)
             await cache.set(
-                self._cache_prefix + task_id, json.dumps(value), expire=60 * 60 * 1)
+                self._cache_prefix + task_id, json.dumps(value))
 
     async def get(self, task_id):
         cache = await self.get_cache()
@@ -111,50 +202,99 @@ class RedisStateManager:
             value = await cache.get(self._cache_prefix + task_id)
             if value:
                 return json.loads(value)
+        return {}
+
+    async def exists(self, task_id):
+        data = await self.get(task_id)
+        return data is not None
 
     async def list(self):
-        # Exception is raised if no cache is found
         cache = await self.get_cache()
-
         async for key in cache.iscan(match=f'{self._cache_prefix}*'):
             yield key.decode().replace(self._cache_prefix, '')
 
-    async def acquire(self, task_id, ttl=None):
+    async def acquire(self, task_id, ttl):
+        if await self.is_locked(task_id):
+            raise TaskAlreadyAcquired(task_id)
+
+        # Set the lock
         cache = await self.get_cache()
-        resp = await cache.setnx(f'lock:{task_id}', self.worker_id)
+        resp = await cache.setnx(self.lock_prefix(task_id), self.worker_id)
         if not resp:
-            worker_id = await cache.get(f'lock:{task_id}')
-            remaining = await cache.ttl(f'lock:{task_id}')
-            if worker_id == self.worker_id:
-                return True, remaining
-            return False, remaining
-        elif ttl:
-            await cache.expire(f'lock:{task_id}', ttl)
-        return True, ttl
+            raise Exception(f'Error acquiring {task_id}')
+
+        # Need to set an expiration for the lock in redis at creation
+        # time
+        refreshed = await self.refresh_lock(task_id, ttl)
+        return refreshed
+
+    async def is_locked(self, task_id):
+        cache = await self.get_cache()
+        resp = await cache.get(self.lock_prefix(task_id))
+        return resp is not None
+
+    async def is_mine(self, task_id):
+        cache = await self.get_cache()
+        task_owner_id = await cache.get(self.lock_prefix(task_id))
+        if not task_owner_id:
+            return False
+        return task_owner_id.decode() == self.worker_id
 
     async def release(self, task_id):
+        if not await self.is_locked(task_id):
+            # There is no lock, nothing to do
+            return False
+        if not await self.is_mine(task_id):
+            # You can't release a task for which you don't own a lock
+            raise TaskAccessUnauthorized
         cache = await self.get_cache()
-        resp = await cache.delete(f'lock:{task_id}')
+        resp = await cache.delete(self.lock_prefix(task_id))
+        return resp > 0
+
+    async def refresh_lock(self, task_id, ttl):
+        if not await self.is_locked(task_id):
+            # There is no lock, nothing to do
+            return False
+
+        if not await self.is_mine(task_id):
+            # You can't release a task for which you don't own a lock
+            raise TaskAccessUnauthorized(task_id)
+
+        cache = await self.get_cache()
+        resp = await cache.expire(self.lock_prefix(task_id), ttl)
         return resp > 0
 
     async def cancel(self, task_id):
         cache = await self.get_cache()
         current_time = time.time()
-        resp = await cache.zadd(f'{self._cache_prefix}cancel',
+        resp = await cache.zadd(self.cancel_prefix,
                                 current_time, task_id)
         return resp > 0
 
     async def cancelation_list(self):
         cache = await self.get_cache()
-
-        async for val, score in cache.izscan(f'{self._cache_prefix}cancel'):
+        async for val, score in cache.izscan(self.cancel_prefix):
             yield val.decode()
 
-    async def clean_cancelled(self, task_id):
-        ...
+    async def clean_canceled(self, task_id):
+        cache = await self.get_cache()
+        resp = await cache.zrem(self.cancel_prefix, task_id)
+        return resp > 0
+
+    async def is_canceled(self, task_id):
+        async for tid in self.cancelation_list():
+            if tid == task_id:
+                return True
+        return False
+
+    async def _clean(self):
+        await self._cache.flushall()
 
 
 class TaskState:
+    """Wrapper around state_manager implementation so we can use it by
+    just having a task_id
+    """
 
     def __init__(self, task_id):
         self.task_id = task_id
@@ -163,16 +303,16 @@ class TaskState:
         util = get_state_manager()
         while True:
             data = await util.get(self.task_id)
-            if data is None:
+            if not data:
                 raise TaskNotFoundException(self.task_id)
-            if data.get('status') in ('finished', 'errored'):
+            if data.get('status') in ('finished', 'errored', 'canceled'):
                 return data
             await asyncio.sleep(wait)
 
     async def get_state(self):
         util = get_state_manager()
         data = await util.get(self.task_id)
-        if data is None:
+        if not data:
             raise TaskNotFoundException(self.task_id)
         return data
 
@@ -181,20 +321,21 @@ class TaskState:
         possible statuses:
         - scheduled
         - consumed
+        - canceled
         - running
         - finished
         - errored
         '''
         util = get_state_manager()
         data = await util.get(self.task_id)
-        if data is None:
+        if not data:
             raise TaskNotFoundException(self.task_id)
         return data.get('status')
 
     async def get_result(self):
         util = get_state_manager()
         data = await util.get(self.task_id)
-        if data is None:
+        if not data:
             raise TaskNotFoundException(self.task_id)
         if data.get('status') not in ('finished', 'errored'):
             raise TaskNotFinishedException(self.task_id)
@@ -202,23 +343,26 @@ class TaskState:
 
     async def cancel(self):
         util = get_state_manager()
-        await util.cancel(self.task_id)
+        return await util.cancel(self.task_id)
 
-    async def acquire(self, timeout=None):
+    async def acquire(self, ttl=DEFAULT_LOCK_TTL_S):
         util = get_state_manager()
-        elapsed = time.time()
+        try:
+            await util.acquire(self.task_id, ttl)
+        except TaskAlreadyAcquired:
+            logger.warning(f'Task {self.task_id} is already taken')
+            return False
+        else:
+            return True
 
-        while True:
-            locked, ttl = await util.acquire(self.task_id, 120)
-            if locked:
-                return True
-
-            if timeout and ((time.time() - elapsed) > timeout):
-                return False
-
-            if not locked and ttl:
-                await asyncio.sleep(ttl)
+    async def refresh_lock(self, ttl=DEFAULT_LOCK_TTL_S):
+        util = get_state_manager()
+        await util.refresh_lock(self.task_id, ttl)
 
     async def release(self):
         util = get_state_manager()
         await util.release(self.task_id)
+
+    async def is_canceled(self):
+        util = get_state_manager()
+        return await util.is_canceled(self.task_id)

--- a/guillotina_amqp/state.py
+++ b/guillotina_amqp/state.py
@@ -67,7 +67,7 @@ class MemoryStateManager:
         # Set new lock
         from guillotina_amqp.utils import TimeoutLock
         lock = TimeoutLock(self.worker_id)
-        lock.acquire(ttl=ttl)
+        await lock.acquire(ttl=ttl)
         self._locks[task_id] = lock
 
     async def is_mine(self, task_id):
@@ -101,7 +101,7 @@ class MemoryStateManager:
             raise TaskAccessUnauthorized(task_id)
 
         # Refresh
-        return self._locks[task_id].refresh_lock(ttl)
+        return await self._locks[task_id].refresh_lock(ttl)
 
     async def cancel(self, task_id):
         self._canceled.update({task_id})

--- a/guillotina_amqp/state.py
+++ b/guillotina_amqp/state.py
@@ -117,9 +117,9 @@ class RedisStateManager:
         cache = await self.get_cache()
 
         async for key in cache.iscan(match=f'{self._cache_prefix}*'):
-            yield key.decode()
+            yield key.decode().replace(self._cache_prefix, '')
 
-    async def adquire(self, task_id, ttl=None):
+    async def acquire(self, task_id, ttl=None):
         cache = await self.get_cache()
         resp = await cache.setnx(f'lock:{task_id}', self.worker_id)
         if not resp:
@@ -195,12 +195,12 @@ class TaskState:
         util = get_state_manager()
         await util.cancel(self.task_id)
 
-    async def adquire(self, timeout=None):
+    async def acquire(self, timeout=None):
         util = get_state_manager()
         elapsed = time.time()
 
         while True:
-            locked, ttl = await util.adquire(self.task_id, 120)
+            locked, ttl = await util.acquire(self.task_id, 120)
             if locked:
                 return True
 

--- a/guillotina_amqp/state.py
+++ b/guillotina_amqp/state.py
@@ -74,6 +74,7 @@ class RedisStateManager:
 
     def __init__(self):
         self._cache = None
+        self.worker_id = 'xxx'
 
     async def get_cache(self):
         if self._cache == _EMPTY:
@@ -109,6 +110,16 @@ class RedisStateManager:
             if value:
                 return json.loads(value)
 
+    async def list(self):
+        # Exception is raised if no cache is found
+        cache = await self.get_cache()
+
+        async for key in await cache.iscan(f'{self._cache_prefix}*'):
+            yield key
+
+    async def lock(self, task_id, timeout=None, ttl=None):
+        cache = await self.get_cache()
+        coro = await cache.setnx(f'lock:{task_id}', self.worker_id)
 
 class TaskState:
 

--- a/guillotina_amqp/tests/__init__.py
+++ b/guillotina_amqp/tests/__init__.py
@@ -1,0 +1,7 @@
+import logging
+from guillotina_amqp.job import logger as logger_job
+from guillotina_amqp.worker import logger as logger_worker
+
+logging.basicConfig()
+logger_job.setLevel(10)
+logger_worker.setLevel(10)

--- a/guillotina_amqp/tests/conftest.py
+++ b/guillotina_amqp/tests/conftest.py
@@ -1,4 +1,5 @@
 pytest_plugins = [
     'guillotina.tests.fixtures',
     'guillotina_amqp.tests.fixtures',
+    'pytest_docker_fixtures',
 ]

--- a/guillotina_amqp/tests/fixtures.py
+++ b/guillotina_amqp/tests/fixtures.py
@@ -12,7 +12,7 @@ base_amqp_settings = {
     "login": "guest",
     "password": "guest",
     "vhost": "/",
-    "heartbeat": 800,
+    "heartbeat": 120,  # 2 minutes
     "exchange": "",
     "queue": "guillotina",
     "persistent_manager": "memory",
@@ -95,7 +95,7 @@ def rabbitmq_container(rabbitmq):
         "login": "guest",
         "password": "guest",
         "vhost": "/",
-        "heartbeat": 800,
+        "heartbeat": 120,  # 2 minutes
         "exchange": "guillotina",
         "queue": "guillotina",
     })

--- a/guillotina_amqp/tests/fixtures.py
+++ b/guillotina_amqp/tests/fixtures.py
@@ -1,7 +1,22 @@
 from guillotina import testing
 import pytest
 from guillotina_amqp.worker import Worker
+from guillotina_amqp import amqp
 from guillotina import app_settings
+import uuid
+
+base_amqp_settings = {
+    "connection_factory": "guillotina_amqp.tests.mocks.amqp_connection_factory",
+    "host": "localhost",
+    "port": 5673,
+    "login": "guest",
+    "password": "guest",
+    "vhost": "/",
+    "heartbeat": 800,
+    "exchange": "",
+    "queue": "guillotina",
+    "persistent_manager": "memory",
+}
 
 
 def base_settings_configurator(settings):
@@ -11,29 +26,76 @@ def base_settings_configurator(settings):
         ])
     else:
         settings['applications'] = ['guillotina_amqp', 'guillotina_amqp.tests.package']
-    settings['amqp'] = {
-        "connection_factory": "guillotina_amqp.tests.mocks.amqp_connection_factory",
-        "host": "localhost",
-        "port": 5673,
-        "login": "guest",
-        "password": "guest",
-        "vhost": "/",
-        "heartbeat": 800,
-        "exchange": "",
-        "queue": "guillotina",
-        "persistent_manager": "memory"
-    }
+    settings['amqp'] = base_amqp_settings
 
 
 testing.configure_with(base_settings_configurator)
 
 
 @pytest.fixture('function')
-def amqp_worker(loop):
+def amqp_worker(loop, rabbitmq_container):
+    # Create worker
     _worker = Worker(loop=loop)
+    _worker.update_status_interval = 2
     loop.run_until_complete(_worker.start())
+
     yield _worker
+
+    # Tear down worker
     for conn in [v for v in app_settings['amqp'].get('connections', []).values()]:
         loop.run_until_complete(conn['protocol'].close())
     _worker.cancel()
     app_settings['amqp']['connections'] = {}
+
+
+@pytest.fixture('function', params=[
+    {'redis_up': True},
+    {'redis_up': False},
+])
+def configured_state_manager(request, redis, dummy_request, loop):
+    if request.param.get('redis_up'):
+        # Redis
+        app_settings['amqp']['persistent_manager'] = 'redis'
+        app_settings['redis_prefix_key'] = f'amqpjobs-{uuid.uuid4()}-'
+        app_settings.update({"redis": {
+            'host': redis[0],
+            'port': redis[1],
+            'pool': {
+                "minsize": 1,
+                "maxsize": 5,
+            },
+        }})
+        print('Running with redis')
+        yield redis
+
+        # NOTE: we need to close the redis pool otherwise it's
+        # attached to the first loop and the nexts tests have new
+        # loops, which causes its to crash
+        from guillotina_rediscache.cache import close_redis_pool
+        loop.run_until_complete(close_redis_pool())
+    else:
+        # Memory
+        app_settings['amqp']['persistent_manager'] = 'memory'
+        print('Running with memory')
+        yield
+
+
+@pytest.fixture('function')
+async def amqp_channel():
+    channel, transport, protocol = await amqp.get_connection()
+    return channel
+
+
+@pytest.fixture('function')
+def rabbitmq_container(rabbitmq):
+    app_settings['amqp'].update({
+        "connection_factory": "aioamqp.connect",
+        "host": rabbitmq[0],
+        "port": rabbitmq[1],
+        "login": "guest",
+        "password": "guest",
+        "vhost": "/",
+        "heartbeat": 800,
+        "exchange": "guillotina",
+        "queue": "guillotina",
+    })

--- a/guillotina_amqp/tests/package.py
+++ b/guillotina_amqp/tests/package.py
@@ -15,6 +15,7 @@ async def task_object_write(ob, value):
 
 @configure.service(name='@foobar', method='GET')
 async def foobar(context, request):
+    # Endpoint to be used in tests to add a function task
     return {
         'task_id': (
             await add_task(task_foobar_yo, 1, 2, three='hello!')
@@ -24,6 +25,7 @@ async def foobar(context, request):
 
 @configure.service(name='@foobar-write', method='GET')
 async def foobar_write(context, request):
+    # Endpoint to be used in tests to add an object function task
     return {
         'task_id': (
             await add_object_task(task_object_write, context, 'Foobar written')

--- a/guillotina_amqp/tests/test_api.py
+++ b/guillotina_amqp/tests/test_api.py
@@ -30,18 +30,17 @@ async def test_info_task(container_requester, dummy_request):
     async with container_requester as requester:
         # Check error status if task_id not specified
         resp, status = await requester('GET', '/db/guillotina/@amqp-info')
-        assert status == 412
-        assert resp['reason'] == 'Missing task_id'
+        assert status == 404
 
         # Check returns correctly if existing task_id
         resp, status = await requester(
-            'GET', f'/db/guillotina/@amqp-info?task_id={t1.task_id}')
+            'GET', f'/db/guillotina/@amqp-info/{t1.task_id}')
         assert status == 200
         assert resp['status'] == 'scheduled'
 
         # Check returns 404 if task_id is not known
         resp, status = await requester(
-            'GET', f'/db/guillotina/@amqp-info?task_id=foo')
+            'GET', '/db/guillotina/@amqp-info/foo')
         assert status == 404
         assert resp['reason'] == 'Task not found'
 
@@ -58,25 +57,23 @@ async def test_cancel_task(container_requester, dummy_request):
         # Check error status if task_id not specified
         resp, status = await requester(
             'DELETE', '/db/guillotina/@amqp-cancel')
-        assert status == 412
-        assert resp['reason'] == 'Missing task_id'
+        assert status == 404
 
         # Check returns correctly if existing task_id
         resp, status = await requester(
-            'DELETE', f'/db/guillotina/@amqp-cancel?task_id={t1.task_id}')
+            'DELETE', f'/db/guillotina/@amqp-cancel/{t1.task_id}')
         assert status == 200
-        assert resp['ok']  # success
+        assert resp is True
 
         # Check returns correctly if already canceled task_id
         resp, status = await requester(
-            'DELETE', f'/db/guillotina/@amqp-cancel?task_id={t1.task_id}')
+            'DELETE', f'/db/guillotina/@amqp-cancel/{t1.task_id}')
         assert status == 200
-        assert resp['ok']
-        assert resp['info'] == 'already canceled'
+        assert resp is True
 
         # Check returns 404 is unknown task
         resp, status = await requester(
-            'DELETE', f'/db/guillotina/@amqp-cancel?task_id=foo')
+            'DELETE', '/db/guillotina/@amqp-cancel/foo')
         assert status == 404
 
     aiotask_context.set('request', None)

--- a/guillotina_amqp/tests/test_api.py
+++ b/guillotina_amqp/tests/test_api.py
@@ -1,0 +1,82 @@
+from guillotina_amqp.utils import add_task
+from guillotina_amqp.tests.utils import _test_func
+
+import aiotask_context
+
+
+async def test_list_tasks_returns_all_tasks(container_requester, dummy_request):
+    aiotask_context.set('request', dummy_request)
+
+    # Add some tasks first
+    t1 = await add_task(_test_func, 1, 2)
+    t2 = await add_task(_test_func, 3, 4)
+
+    async with container_requester as requester:
+        resp, status = await requester('GET', '/db/guillotina/@amqp-tasks')
+        assert status == 200
+        assert len(resp) == 2
+        assert t1.task_id in resp
+        assert t2.task_id in resp
+
+    aiotask_context.set('request', None)
+
+
+async def test_info_task(container_requester, dummy_request):
+    aiotask_context.set('request', dummy_request)
+
+    # Add some tasks first
+    t1 = await add_task(_test_func, 1, 2)
+
+    async with container_requester as requester:
+        # Check error status if task_id not specified
+        resp, status = await requester('GET', '/db/guillotina/@amqp-info')
+        assert status == 412
+        assert resp['reason'] == 'Missing task_id'
+
+        # Check returns correctly if existing task_id
+        resp, status = await requester(
+            'GET', f'/db/guillotina/@amqp-info?task_id={t1.task_id}')
+        assert status == 200
+        assert resp['status'] == 'scheduled'
+
+        # Check returns 404 if task_id is not known
+        resp, status = await requester(
+            'GET', f'/db/guillotina/@amqp-info?task_id=foo')
+        assert status == 404
+        assert resp['reason'] == 'Task not found'
+
+    aiotask_context.set('request', None)
+
+
+async def test_cancel_task(container_requester, dummy_request):
+    aiotask_context.set('request', dummy_request)
+
+    # Add some tasks first
+    t1 = await add_task(_test_func, 1, 2)
+
+    async with container_requester as requester:
+        # Check error status if task_id not specified
+        resp, status = await requester(
+            'DELETE', '/db/guillotina/@amqp-cancel')
+        assert status == 412
+        assert resp['reason'] == 'Missing task_id'
+
+        # Check returns correctly if existing task_id
+        resp, status = await requester(
+            'DELETE', f'/db/guillotina/@amqp-cancel?task_id={t1.task_id}')
+        assert status == 200
+        assert resp['ok']  # success
+
+        # Check returns correctly if already canceled task_id
+        resp, status = await requester(
+            'DELETE', f'/db/guillotina/@amqp-cancel?task_id={t1.task_id}')
+        assert status == 200
+        assert resp['ok']
+        assert resp['info'] == 'already canceled'
+
+        # Check returns 404 is unknown task
+        resp, status = await requester(
+            'DELETE', f'/db/guillotina/@amqp-cancel?task_id=foo')
+        assert status == 404
+
+    aiotask_context.set('request', None)

--- a/guillotina_amqp/tests/test_state.py
+++ b/guillotina_amqp/tests/test_state.py
@@ -1,0 +1,105 @@
+from guillotina_amqp.state import get_state_manager
+from guillotina_amqp.exceptions import TaskAlreadyAcquired
+from guillotina_amqp.exceptions import TaskAccessUnauthorized
+
+import pytest
+import asyncio
+
+
+async def clear_cache(sm):
+    await sm._clean()
+
+
+async def test_update_and_get_should_match(configured_state_manager, loop):
+    state_manager = get_state_manager(loop)
+    await state_manager.update('foo', {'state': 'bar'})
+    data = await state_manager.get('foo')
+    assert data['state'] == 'bar'
+    await clear_cache(state_manager)
+
+
+async def test_acquire_should_block_further_acquires(configured_state_manager, loop):
+    state_manager = get_state_manager(loop)
+    FOREVER = 300
+    await state_manager.acquire('foo', ttl=FOREVER)
+    with pytest.raises(TaskAlreadyAcquired):
+        await state_manager.acquire('foo', ttl=FOREVER)
+    # Release it and acquire again
+    await state_manager.release('foo')
+    await state_manager.acquire('foo', ttl=FOREVER)
+    await clear_cache(state_manager)
+
+
+async def test_acquire_should_unblock_after_ttl(configured_state_manager, loop):
+    state_manager = get_state_manager(loop)
+    await state_manager.acquire('foo', ttl=1)
+    with pytest.raises(TaskAlreadyAcquired):
+        await state_manager.acquire('foo', ttl=300)
+    # Wait for the ttl and check
+    await asyncio.sleep(1.1)
+    await state_manager.acquire('foo', ttl=1)
+    await clear_cache(state_manager)
+
+
+async def test_list_should_yield_all_items(configured_state_manager, loop):
+    state_manager = get_state_manager(loop)
+    tasks = set({'t1', 't2', 't3', 't4', 't5'})
+    for task_id in tasks:
+        await state_manager.update(task_id, {'state': f'{task_id} is OK!'})
+    assert set([tid async for tid in state_manager.list()]) == tasks
+    await clear_cache(state_manager)
+
+
+async def test_cancel_should_put_tasks_in_cancelation_list(configured_state_manager, loop):
+    state_manager = get_state_manager(loop)
+    await state_manager.update('foo', {'status': 'bar'})
+    canceled_list = [tid async for tid in state_manager.cancelation_list()]
+    assert 'foo' not in canceled_list
+    await state_manager.cancel('foo')
+    canceled_list = [tid async for tid in state_manager.cancelation_list()]
+    assert 'foo' in canceled_list
+    await clear_cache(state_manager)
+
+
+async def test_clean_cancel_should_clean_from_canceled_list(configured_state_manager, loop):
+    state_manager = get_state_manager(loop)
+    await state_manager.cancel('foo')
+    canceled_list = [tid async for tid in state_manager.cancelation_list()]
+    assert 'foo' in canceled_list
+    await state_manager.clean_canceled('foo')
+    canceled_list = [tid async for tid in state_manager.cancelation_list()]
+    assert 'foo' not in canceled_list
+    await clear_cache(state_manager)
+
+
+async def test_is_canceled_should_return_true_only_on_canceled_tasks(configured_state_manager, loop):
+    state_manager = get_state_manager(loop)
+    await state_manager.cancel('foo')
+    assert await state_manager.is_canceled('foo')
+    assert not await state_manager.is_canceled('bar')
+    await clear_cache(state_manager)
+
+
+async def test_refresh_should_raise_if_task_is_not_yours(configured_state_manager, loop):
+    state_manager = get_state_manager(loop)
+    state_manager.worker_id = 'me'
+    await state_manager.acquire('footask', ttl=120)
+    await state_manager.refresh_lock('footask', ttl=20)
+    with pytest.raises(TaskAccessUnauthorized):
+        state_manager.worker_id = 'another_person'
+        await state_manager.refresh_lock('footask', 120)
+    state_manager.worker_id = 'me'
+    await state_manager.refresh_lock('footask', 20)
+    await clear_cache(state_manager)
+
+
+async def test_release_should_raise_if_task_is_not_yours(configured_state_manager, loop):
+    state_manager = get_state_manager(loop)
+    state_manager.worker_id = 'me'
+    await state_manager.acquire('footask', ttl=120)
+    with pytest.raises(TaskAccessUnauthorized):
+        state_manager.worker_id = 'another_person'
+        await state_manager.release('footask')
+    state_manager.worker_id = 'me'
+    await state_manager.release('footask')
+    await clear_cache(state_manager)

--- a/guillotina_amqp/tests/utils.py
+++ b/guillotina_amqp/tests/utils.py
@@ -1,0 +1,42 @@
+from guillotina_amqp.decorators import task
+import asyncio
+
+
+async def _test_func(one, two, one_keyword=None):
+    return one + two
+
+
+async def _test_asyncgen(one, two, one_keyword=None):
+    yield (1, 'Starting task')
+    yield (1, 'Yellow')
+    yield (0, one + two)
+
+
+async def _test_asyncgen_invalid():
+    yield (1, 1, 2, 3)
+    yield (0)
+
+
+async def _test_asyncgen_doubley(arg1, arg2, arg3):
+    yield (0, arg1)
+    yield (0, arg2)
+    yield (1, 'OK')
+    yield (0, arg3)
+
+
+@task
+async def _test_long_func(duration):
+    print('Started task')
+    await asyncio.sleep(duration)
+    print('Finished task')
+    return 'done!'
+
+
+@task
+async def _test_failing_func():
+    raise Exception('Foobar')
+
+
+@task
+async def _decorator_test_func(one, two):
+    return one + two

--- a/guillotina_amqp/utils.py
+++ b/guillotina_amqp/utils.py
@@ -16,12 +16,27 @@ import json
 import logging
 import time
 import uuid
+import threading
+import asyncio
 
 
-logger = logging.getLogger('guillotina_amqp')
+logger = logging.getLogger('guillotina_amqp.utils')
+
+
+async def cancel_task(task_id):
+    """It cancels a task by id. Returns wether it could be cancelled.
+
+    """
+    task = TaskState(task_id)
+    success = await task.cancel()
+    return success
 
 
 async def add_task(func, *args, _request=None, _retries=3, **kwargs):
+    """Given a function and its arguments, it adds it as a task to be ran
+    by workers.
+    """
+    # Get the request and prepare request data
     if _request is None:
         _request = get_current_request()
 
@@ -50,6 +65,7 @@ async def add_task(func, *args, _request=None, _retries=3, **kwargs):
 
     retries = 0
     while True:
+        # Get the rabbitmq connection
         channel, transport, protocol = await amqp.get_connection()
         try:
             task_id = str(uuid.uuid4())
@@ -65,6 +81,7 @@ async def add_task(func, *args, _request=None, _retries=3, **kwargs):
                 'req_data': req_data,
                 'task_id': task_id
             })
+            # Publish task data on rabbitmq
             await channel.publish(
                 data,
                 exchange_name=app_settings['amqp']['exchange'],
@@ -73,6 +90,7 @@ async def add_task(func, *args, _request=None, _retries=3, **kwargs):
                     'delivery_mode': 2
                 }
             )
+            # Update tasks's global state
             state_manager = get_state_manager()
             await state_manager.update(task_id, {
                 'status': 'scheduled',
@@ -101,3 +119,42 @@ async def add_object_task(callable=None, ob=None, *args,
     return await add_task(
         _run_object_task, get_dotted_name(callable), get_content_path(ob), *args,
         _request=_request, _retries=_retries, **kwargs)
+
+
+class TimeoutLock(object):
+    """Implements a Lock that can be acquired for """
+    def __init__(self, worker_id):
+        self._lock = threading.Lock()
+        self.worker_id = worker_id
+        self._thread = None
+
+    def acquire(self, ttl=-1, blocking=True):
+        """If ttl is -1, lock will be acquired forever (or until someone
+        manually releases it).
+
+        Otherwise, it schedules an automatic release after the
+        specified ttl.
+        """
+        acquired = self._lock.acquire(blocking)
+        if not acquired:
+            return False
+
+        if ttl >= 0:
+            asyncio.ensure_future(self._release_after(ttl))
+        return True
+
+    async def _release_after(self, some_time):
+        await asyncio.sleep(some_time)
+        self.release()
+
+    def release(self):
+        if self.locked():
+            self._lock.release()
+
+    def locked(self):
+        return self._lock.locked()
+
+    def refresh_lock(self, ttl):
+        # Overwrite old lock and acquire with new timeout
+        self._lock = threading.Lock()
+        return self.acquire(ttl)

--- a/guillotina_amqp/utils.py
+++ b/guillotina_amqp/utils.py
@@ -126,7 +126,6 @@ class TimeoutLock(object):
     def __init__(self, worker_id):
         self._lock = threading.Lock()
         self.worker_id = worker_id
-        self._thread = None
 
     def acquire(self, ttl=-1, blocking=True):
         """If ttl is -1, lock will be acquired forever (or until someone

--- a/guillotina_amqp/worker.py
+++ b/guillotina_amqp/worker.py
@@ -1,7 +1,15 @@
+"""
+NOTE:
+ - Task: used to refer to an asyncio task
+ - Job: used to refer a specification of some work that has to be done
+"""
+
 from guillotina import app_settings
 from guillotina_amqp import amqp
 from guillotina_amqp.job import Job
 from guillotina_amqp.state import get_state_manager, TaskState
+from guillotina_amqp.exceptions import TaskAlreadyAcquired
+from guillotina_amqp.exceptions import TaskAlreadyCanceled
 
 import asyncio
 import json
@@ -9,13 +17,24 @@ import logging
 import time
 
 
-logger = logging.getLogger('guillotina_amqp')
+logger = logging.getLogger('guillotina_amqp.worker')
 
 
 class Worker:
+    """Workers hold an asyncio loop in which will run several tasks. It
+    reads from RabbitMQ for new job descriptions and will run them in
+    asyncio tasks.
+
+    The worker is aware of a state manager in which he posts job
+    results.
+
+    """
     sleep_interval = 0.05
     last_activity = time.time()
+    update_status_interval = 20
     total_run = 0
+    total_errored = 0
+    max_task_retries = 5
 
     def __init__(self, request=None, loop=None, max_size=5):
         self.request = request
@@ -26,6 +45,14 @@ class Worker:
         self._closing = False
         self._state_manager = None
 
+        # RabbitMQ queue names defined here
+        self.EXCHANGE = app_settings['amqp']['exchange']
+        self.QUEUE_MAIN = app_settings['amqp']['queue']
+        self.QUEUE_ERRORED = app_settings['amqp']['queue'] + '-error'
+        self.QUEUE_DELAYED = app_settings['amqp']['queue'] + '-delay'
+        self.TTL_ERRORED = 1000 * 60 * 60 * 24 * 7  # 1 week
+        self.TTL_DELAYED = 1000 * 60 * 1  # 1 minute
+
     @property
     def state_manager(self):
         if self._state_manager is None:
@@ -34,12 +61,22 @@ class Worker:
 
     @property
     def num_running(self):
+        """Returns the number of currently running jobs"""
         return len(self._running)
 
     async def handle_queued_job(self, channel, body, envelope, properties):
+        """Callback triggered when there is a new job in the job channel (e.g:
+        a new task in a rabbitmq queue)
+
+        """
+        logger.debug(f'Queued job {body}')
+
+        # Deserialize job description
         if not isinstance(body, str):
             body = body.decode('utf-8')
         data = json.loads(body)
+
+        # Set status to scheduled
         task_id = data['task_id']
         dotted_name = data['func']
         await self.state_manager.update(task_id, {
@@ -47,91 +84,265 @@ class Worker:
             'updated': time.time()
         })
         logger.info(f'Received task: {task_id}: {dotted_name}')
+
+        # Block if we reached maximum number of running tasks
         while len(self._running) >= self._max_size:
             await asyncio.sleep(self.sleep_interval)
             self.last_activity = time.time()
+
+        # Create job object
         self.last_activity = time.time()
         job = Job(self.request, data, channel, envelope)
-
+        # Get the redis lock on the task so no other worker takes it
         _id = job.data['task_id']
         ts = TaskState(_id)
-        res = await ts.acquire(timeout=120)
-        if not res:
-            raise Exception()
 
+        # Cancelation
+        if await ts.is_canceled():
+            logger.warning(f'Task {_id} has already been canceled')
+            raise TaskAlreadyCanceled(_id)
 
+        try:
+            await ts.acquire()
+        except TaskAlreadyAcquired:
+            logger.warning(f'Task {_id} is already running in another worker')
+            # TODO: ACK task
+
+        # Record job's data into global state
+        await self.state_manager.update(task_id, {
+            'job_data': job.data,
+        })
+
+        # Add the task to the loop and start it
         task = self.loop.create_task(job())
         task._job = job
         job.task = task
         self._running.append(task)
-        task.add_done_callback(self._done_callback)
+        task.add_done_callback(self._task_done_callback)
 
-    def _done_callback(self, task):
+    async def _handle_canceled(self, task):
+        self._running.remove(task)
+        task_id = task._job.data['task_id']
+        # ACK to main queue to it is not scheduled anymore
+        await task._job.channel.basic_client_ack(
+            delivery_tag=task._job.envelope.delivery_tag)
+
+        # Set status to cancelled
+        await self.state_manager.update(task_id, {
+            'status': 'canceled',
+            'error': task.print_stack(),
+        })
+
+    async def _handle_max_retries_reached(self, task):
+        task_id = task._job.data['task_id']
+        logger.warning(
+            f'Task {task_id} reached max {self.max_task_retries} retries')
+
+        # Send NACK, as we exceeded the number of retrials
+        await task._job.channel.basic_client_nack(
+            delivery_tag=task._job.envelope.delivery_tag,
+            multiple=False, requeue=False)
+
+        # Update status to errored with the traceback
+        await self.state_manager.update(task_id, {
+            'status': 'errored',
+            'error': task.print_stack(),
+        })
+
+    async def _handle_retry(self, task, current_retries):
+        task_id = task._job.data['task_id']
+        channel = task._job.channel
+        logger.debug(f'handle_retry: task {task_id} retries {current_retries}')
+        # Increment retry count
+        await self.state_manager.update(task_id, {
+            'job_retries': current_retries + 1,
+            'status': 'errored',
+            'error': task.print_stack()
+        })
+
+        # Publish task data to delay queue
+        await channel.publish(
+            json.dumps(task._job.data),
+            exchange_name=self.EXCHANGE,
+            routing_key=self.QUEUE_DELAYED,
+            properties={
+                'delivery_mode': 2
+            }
+        )
+        # ACK to main queue so it doesn't timeout
+        await channel.basic_client_ack(
+            delivery_tag=task._job.envelope.delivery_tag)
+        logger.info(f'Task {task_id} will be retried')
+
+    async def _handle_successful(self, task):
+        task_id = task._job.data['task_id']
+        dotted_name = task._job.data['func']
+        # ACK rabbitmq: will make task disappear from rabbitmq
+        await task._job.channel.basic_client_ack(
+            delivery_tag=task._job.envelope.delivery_tag)
+
+        # Update status with result
+        await self.state_manager.update(task_id, {
+            'status': 'finished',
+            'result': task.result(),
+        })
+        logger.info(f'Finished task: {task_id}: {dotted_name}')
+
+    def _task_done_callback(self, task):
+        # We can't pass coroutines to add_done_callback so we have to
+        # place it inside an ensure_future
+        asyncio.ensure_future(self._task_callback(task))
+
+    async def _task_callback(self, task):
+        """This is called when a job finishes execution"""
+        task_id = task._job.data['task_id']
         self._done.append(task)
         self.total_run += 1
 
+        try:
+            result = task.result()
+            logger.debug(f'Task data: {task._job.data}, result: {result}')
+        except asyncio.CancelledError:
+            logger.warning(f'Task got cancelled: {task._job.data}', exc_info=True)
+            return await self._handle_canceled(task)
+        except Exception:
+            # Error during execution of the task
+            #
+            # If max retries reached
+            existing_data = await self.state_manager.get(task_id)
+            retrials = existing_data.get('job_retries', 0)
+            if retrials >= self.max_task_retries:
+                return await self._handle_max_retries_reached(task)
+
+            # Otherwise let task be retried
+            return await self._handle_retry(task, retrials)
+        else:
+            # If task ran successfully, ACK main queue and finish
+            return await self._handle_successful(task)
+
     async def start(self):
+        """Called on worker startup. Connects to the rabbitmq. Declares and
+        configures the different queues.
+
+        """
         channel, transport, protocol = await amqp.get_connection()
 
+        # Declare main exchange
         await channel.exchange_declare(
-            exchange_name=app_settings['amqp']['exchange'],
+            exchange_name=self.EXCHANGE,
             type_name='direct',
             durable=True)
 
-        await channel.queue_declare(
-            queue_name=app_settings['amqp']['queue'] + '-error', durable=True,
-            arguments={
-                'x-message-ttl': 1000 * 60 * 60 * 24 * 7
-            })
-        await channel.queue_declare(
-            queue_name=app_settings['amqp']['queue'], durable=True,
-            arguments={
-                'x-dead-letter-exchange': app_settings['amqp']['exchange'],
-                'x-dead-letter-routing-key': app_settings['amqp']['queue'] + '-error'
-            })
+        # Declare errored queue and bind it
+        await self.queue_errored(channel, passive=False)
         await channel.queue_bind(
-            exchange_name=app_settings['amqp']['exchange'],
-            queue_name=app_settings['amqp']['queue'],
-            routing_key=app_settings['amqp']['queue'])
+            exchange_name=self.EXCHANGE,
+            queue_name=self.QUEUE_ERRORED,
+            routing_key=self.QUEUE_ERRORED,
+        )
+
+        # Declare main queue and bind it
+        await self.queue_main(channel, passive=False)
+        await channel.queue_bind(
+            exchange_name=self.EXCHANGE,
+            queue_name=self.QUEUE_MAIN,
+            routing_key=self.QUEUE_MAIN,
+        )
+
+        # Declare delayed queue and bind it
+        await self.queue_delayed(channel, passive=False)
+        await channel.queue_bind(
+            exchange_name=self.EXCHANGE,
+            queue_name=self.QUEUE_DELAYED,
+            routing_key=self.QUEUE_DELAYED,
+        )
 
         await channel.basic_qos(prefetch_count=4)
+
+        # Configure consume callback
         await channel.basic_consume(
             self.handle_queued_job,
-            queue_name=app_settings['amqp']['queue'])
+            queue_name=self.QUEUE_MAIN,
+        )
 
+        # Start task that will update status periodically
         asyncio.ensure_future(self.update_status())
 
-        logger.warning(f"Subscribed to queue: {app_settings['amqp']['queue']}")
+        logger.warning(f"Subscribed to queue: {self.QUEUE_MAIN}")
+
+    async def queue_main(self, channel, passive=True):
+        # Main queue
+        # Automatically move NACK tasks to errored queue
+        return await channel.queue_declare(
+            queue_name=self.QUEUE_MAIN, durable=True,
+            passive=passive,
+            arguments={
+                'x-dead-letter-exchange': self.EXCHANGE,
+                'x-dead-letter-routing-key': self.QUEUE_ERRORED,
+            })
+
+    async def queue_delayed(self, channel, passive=True):
+        # Declare delayed queue: set TTL to move taks from delayed
+        # queue to main queue
+        return await channel.queue_declare(
+            queue_name=self.QUEUE_DELAYED, durable=True,
+            passive=passive,
+            arguments={
+                'x-dead-letter-exchange': self.EXCHANGE,
+                'x-dead-letter-routing-key': self.QUEUE_MAIN,
+                'x-message-ttl': self.TTL_DELAYED,
+            })
+
+    async def queue_errored(self, channel, passive=True):
+        # Errored tasks will remain a limited period of time
+        return await channel.queue_declare(
+            queue_name=self.QUEUE_ERRORED, durable=True,
+            passive=passive,
+            arguments={
+                'x-message-ttl': self.TTL_ERRORED,
+            })
 
     def cancel(self):
+        """
+        Cancels the worker (i.e: all its running tasks)
+        """
         for task in self._running:
             task.cancel()
 
     async def join(self):
+        """
+        Waits for all tasks to finish
+        """
         while len(self._running) > 0:
             await asyncio.sleep(0.01)
 
-    async def is_cancelled(self, task_id):
-        return True
-
     async def update_status(self):
+        """Updates status for running tasks and kills running tasks that have
+        been canceled.
+
+        """
         while True:
-            await asyncio.sleep(20)
+            await asyncio.sleep(self.update_status_interval)
             for task in self._running:
                 _id = task._job.data['task_id']
                 ts = TaskState(_id)
+
                 if task in self._done:
+                    # Clean-up completed running task list and release
+                    # lock in StateManager
                     self._running.remove(task)
                     await ts.release()
-                else:
-                    result = await ts.acquire()
-                    if not result:
-                        # kill the task
-                        task.cancel()
 
+                else:
+                    # Still working on the job: refresh task lock
+                    await ts.refresh_lock()
+
+            # Cancel local tasks that have been cancelled in global
+            # state manager
             async for val in self.state_manager.cancelation_list():
                 for task in self._running:
                     _id = task._job.data['task_id']
                     if _id == val:
+                        logger.warning(f"Canceling task {_id}")
                         task.cancel()
-                        await self._state_manager.clean_cancelled(_id)
+                        await self._state_manager.clean_canceled(_id)

--- a/guillotina_amqp/worker.py
+++ b/guillotina_amqp/worker.py
@@ -98,3 +98,6 @@ class Worker:
     async def join(self):
         while len(self._running) > 0:
             await asyncio.sleep(0.01)
+
+    async def refresh_status(self):
+        pass

--- a/guillotina_amqp/worker.py
+++ b/guillotina_amqp/worker.py
@@ -1,9 +1,3 @@
-"""
-NOTE:
- - Task: used to refer to an asyncio task
- - Job: used to refer a specification of some work that has to be done
-"""
-
 from guillotina import app_settings
 from guillotina_amqp import amqp
 from guillotina_amqp.job import Job
@@ -81,7 +75,7 @@ class Worker:
         dotted_name = data['func']
         await self.state_manager.update(task_id, {
             'status': 'scheduled',
-            'updated': time.time()
+            'eventlog': {},
         })
         logger.info(f'Received task: {task_id}: {dotted_name}')
 

--- a/guillotina_amqp/worker.py
+++ b/guillotina_amqp/worker.py
@@ -45,7 +45,7 @@ class Worker:
         self.QUEUE_ERRORED = app_settings['amqp']['queue'] + '-error'
         self.QUEUE_DELAYED = app_settings['amqp']['queue'] + '-delay'
         self.TTL_ERRORED = 1000 * 60 * 60 * 24 * 7  # 1 week
-        self.TTL_DELAYED = 1000 * 60 * 1  # 1 minute
+        self.TTL_DELAYED = 1000 * 60 * 2  # 2 minute
 
     @property
     def state_manager(self):

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ except IOError:
 
 setup(
     name='guillotina_amqp',
-    version='1.0.9.dev0',
+    version='2.0.0',
     description='Integrate amqp into guillotina',
     long_description=README,
     install_requires=[
@@ -35,7 +35,8 @@ setup(
             'pytest-asyncio>=0.8.0',
             'pytest-aiohttp',
             'pytest-cov',
-            'coverage>=4.4'
+            'coverage>=4.4',
+            'pytest-docker-fixtures[rabbitmq]==1.2.5',
         ]
     },
     license='BSD',

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,10 @@ setup(
     description='Integrate amqp into guillotina',
     long_description=README,
     install_requires=[
-        'guillotina>=2.1.5',
+        'guillotina>=4.0.0',
         'aioamqp',
-        'lru-dict'
+        'lru-dict',
+        'guillotina_rediscache==2.0.4',
     ],
     author='Nathan Van Gheem',
     author_email='vangheem@gmail.com',


### PR DESCRIPTION
Major improvements:
 - Added option to have an event loop watchdog at each worker to prevent tasks from clogging it.
 - Added task retrial using delay queue
 - Tasks are only ACK'ed if successful, otherwise are sent to delay queue
 - Allow task cancellation
 - Improved API endpoints and docs
 - Upgraded to guillotina 4
 - Added plenty of tests for worker, amqp and state manager
