### PR TITLE
Improvements in the beacons liveness system

### DIFF
--- a/guillotina_amqp/tests/fixtures.py
+++ b/guillotina_amqp/tests/fixtures.py
@@ -34,6 +34,8 @@ testing.configure_with(base_settings_configurator)
 
 @pytest.fixture('function')
 def amqp_worker(loop, rabbitmq_container):
+    amqp.logger.setLevel(10)
+
     # Create worker
     _worker = Worker(loop=loop)
     _worker.update_status_interval = 2
@@ -98,4 +100,5 @@ def rabbitmq_container(rabbitmq):
         "heartbeat": 120,  # 2 minutes
         "exchange": "guillotina",
         "queue": "guillotina",
+        "beaconttl": 2
     })

--- a/guillotina_amqp/worker.py
+++ b/guillotina_amqp/worker.py
@@ -214,6 +214,10 @@ class Worker:
             # If task ran successfully, ACK main queue and finish
             return await self._handle_successful(task)
 
+    async def stop(self):
+        self.cancel()
+        await amqp.remove_connection()
+
     async def start(self):
         """Called on worker startup. Connects to the rabbitmq. Declares and
         configures the different queues.


### PR DESCRIPTION
* The autokill task just eats cancel events and exits the process otherwise
* The beacon TTL is configured in app_settings['amqp']['beaconttl']
* First beacon is sent by setup_beacon_queues()
* Add a stop() coroutine to the Worker to disconnect from AMQP
* Add a unit test to test that the autokill task works as expected when
  the connection is lost