### PR TITLE
Add a BeaconsManager class responsible for handling beacons

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,9 @@
+2.0.1
+-----
+
+- Don't use globals for the beacons liveness system and move the code
+  to the BeaconsManager class (1 manager per connection) [davidonna]
+
 2.0.0
 -----
 

--- a/guillotina_amqp/amqp.py
+++ b/guillotina_amqp/amqp.py
@@ -13,12 +13,7 @@ import aioamqp.exceptions
 
 logger = logging.getLogger('guillotina_amqp')
 
-autokill_handler = None
-autokill_event = None
-worker_beacon_uuid = uuid.uuid4().hex
-beacon_queue_name = f'beacon-{worker_beacon_uuid}'
-beacon_delay_queue_name = f'beacon-delay-{worker_beacon_uuid}'
-beacon_ttl = 30  # 30 seconds
+beacon_ttl_default = 30  # 30 seconds
 
 
 async def remove_connection(name='default'):
@@ -36,6 +31,7 @@ async def remove_connection(name='default'):
     connection = connections.pop(name)
     try:
         await connection['channel'].close()
+        connection['beaconsmgr'].stop()
     except Exception:
         pass  # could already be closed
     try:
@@ -73,6 +69,13 @@ async def heartbeat():
             logger.error('Error sending heartbeat', exc_info=True)
 
 
+async def get_beaconsmgr_for_connection(name='default'):
+    # Returns the beacons manager associated with an AMQP connection
+    connections = app_settings['amqp']['connections']
+    if name in connections:
+        return connections[name]['beaconsmgr']
+
+
 async def get_connection(name='default'):
     amqp_settings = app_settings['amqp']
     if 'connections' not in amqp_settings:
@@ -82,10 +85,17 @@ async def get_connection(name='default'):
         connection = connections[name]
         return connection['channel'], connection['transport'], connection['protocol']
     channel, transport, protocol = await connect()
+
+    # Create the BeaconsManager and set up the beacon queues
+    beacons_mgr = BeaconsManager(channel,
+                                 ttl=amqp_settings.get('beaconttl', 30))
+    await beacons_mgr.setup_beacon_queues()
+
     connections[name] = {
         'channel': channel,
         'protocol': protocol,
-        'transport': transport
+        'transport': transport,
+        'beaconsmgr': beacons_mgr
     }
     asyncio.ensure_future(handle_connection_closed(name, protocol))
     if amqp_settings.get('heartbeat_task') is None:
@@ -96,135 +106,147 @@ async def get_connection(name='default'):
     return channel, transport, protocol
 
 
-async def setup_beacon_queues(channel, ttl=beacon_ttl):
-    global beacon_queue_name
-    global beacon_delay_queue_name
-    global autokill_handler
-    global autokill_event
+class BeaconsManager:
+    def __init__(self, channel, ttl=beacon_ttl_default):
+        self._ttl = ttl
+        self._stopped = False
+        self.channel = channel
 
-    autokill_event = asyncio.Event()
+        # Autokill task
+        self.autokill_handler = None
 
-    logger.debug(f'Setting up beacon queues with TTL {ttl}')
+        # Autokill-ed event
+        self.autokill_event = None
 
-    # Declare beacon exchange
-    await channel.exchange_declare(
-        exchange_name='beacon',
-        type_name='direct',
-    )
+        # Beacon UUID and queues names
+        self.worker_beacon_uuid = uuid.uuid4().hex
+        self.beacon_queue_name = f'beacon-{self.worker_beacon_uuid}'
+        self.beacon_delay_queue_name = f'beacon-delay-{self.worker_beacon_uuid}'
 
-    # Declare and bind the main beacon temporary queue
-    await channel.queue_declare(
-        queue_name=beacon_queue_name,
-        exclusive=True,  # This deletes the queue if connection is lost
-    )
-    await channel.queue_bind(
-        exchange_name='beacon',
-        queue_name=beacon_queue_name,
-        routing_key=beacon_queue_name,
-    )
+    @property
+    def ttl(self):
+        # Beacon TTL
+        return self._ttl
 
-    # Declare and bind delay beacon temporary queue
-    await channel.queue_declare(
-        queue_name=beacon_delay_queue_name,
-        exclusive=True,  # This deletes the queue if connection is lost
-        arguments={
-            'x-dead-letter-exchange': 'beacon',
-            'x-dead-letter-routing-key': beacon_queue_name,
-            'x-message-ttl': ttl,  # 30 seconds
-        })
+    async def setup_beacon_queues(self):
+        self.autokill_event = asyncio.Event()
 
-    await channel.queue_bind(
-        exchange_name='beacon',
-        queue_name=beacon_delay_queue_name,
-        routing_key=beacon_delay_queue_name,
-    )
+        logger.debug(f'Setting up beacon queues with TTL {self.ttl}')
 
-    # Configure main beacon message handler
-    await channel.basic_consume(
-        handle_beacon,
-        queue_name=beacon_queue_name,
-    )
-
-    # Start the autokill task
-    autokill_handler = asyncio.ensure_future(autokill(ttl))
-
-    # Send the first beacon
-    asyncio.ensure_future(publish_beacon_to_delay_queue(channel, ttl))
-
-
-async def autokill(ttl):
-    """
-    AutoKill task, sleeps as long as beacons are received, and exits the
-    process otherwise
-
-    This task captures cancel events (cancel is called from the beacon handler)
-    and keeps sleeping in that case, otherwise exits the process because that
-    means we didn't receive any beacons (AMQP connection is stalled)
-    """
-    loop = asyncio.get_event_loop()
-
-    while True:
-        try:
-            asleep = ttl * 3
-            logger.debug(f'autokill: sleeping for {asleep} seconds')
-            await asyncio.sleep(asleep)
-        except asyncio.CancelledError:
-            logger.debug(f'autokill: received cancel, beacon was received')
-            continue
-        except Exception as err:
-            logger.debug(f'autokill: unknown exception {err}')
-            continue
-        else:
-            logger.debug(f'autokill: No beacons received')
-            break
-
-    # No beacons received: set the autokill event, and schedule a call
-    # to os._exit a bit later so that unit tests can wait on autokill_event
-
-    logger.error(f'Exiting worker because of no beacon activity')
-
-    autokill_event.set()
-    loop.call_later(2, os._exit, 0)
-
-
-async def publish_beacon_to_delay_queue(channel, wait=0):
-    # Publish to beacon delay queue
-    await asyncio.sleep(wait)
-    try:
-        beacon_payload = json.dumps({'worker_beacon_uuid': worker_beacon_uuid})
-        await channel.publish(
-            beacon_payload,
+        # Declare beacon exchange
+        await self.channel.exchange_declare(
             exchange_name='beacon',
-            routing_key=beacon_delay_queue_name,
-            properties={
-                'delivery_mode': 2,
-            }
+            type_name='direct',
         )
-    except aioamqp.exceptions.ChannelClosed:
-        logger.debug(f'Beacon publish: channel is closed !')
-    else:
-        logger.debug(f'Beacon published: {beacon_payload}')
 
-
-async def handle_beacon(channel, body, envelope, properties):
-    global autokill_handler
-    global worker_beacon_uuid
-    global beacon_delay_queue_name
-
-    logger.debug(f'handle_beacon {body} {channel}')
-
-    if autokill_handler:
-        # ACK beacon queue
-        await channel.basic_client_ack(
-            delivery_tag=envelope.delivery_tag,
+        # Declare and bind the main beacon temporary queue
+        await self.channel.queue_declare(
+            queue_name=self.beacon_queue_name,
+            exclusive=True,  # This deletes the queue if connection is lost
         )
-        # Cancel previous autokill
-        autokill_handler.cancel()
+        await self.channel.queue_bind(
+            exchange_name='beacon',
+            queue_name=self.beacon_queue_name,
+            routing_key=self.beacon_queue_name,
+        )
 
-    # Schedule sending of beacon
-    ttl = app_settings['amqp'].get('beaconttl', None)
-    if ttl:
-        await publish_beacon_to_delay_queue(channel, wait=ttl)
+        # Declare and bind delay beacon temporary queue
+        await self.channel.queue_declare(
+            queue_name=self.beacon_delay_queue_name,
+            exclusive=True,  # This deletes the queue if connection is lost
+            arguments={
+                'x-dead-letter-exchange': 'beacon',
+                'x-dead-letter-routing-key': self.beacon_queue_name,
+                'x-message-ttl': self.ttl,  # 30 seconds
+            })
+
+        await self.channel.queue_bind(
+            exchange_name='beacon',
+            queue_name=self.beacon_delay_queue_name,
+            routing_key=self.beacon_delay_queue_name,
+        )
+
+        # Configure main beacon message handler
+        await self.channel.basic_consume(
+            self.handle_beacon,
+            queue_name=self.beacon_queue_name,
+        )
+
+        # Start the autokill task
+        self.autokill_handler = asyncio.ensure_future(self.autokill(self.ttl))
+
+        # Send the first beacon
+        asyncio.ensure_future(self.publish_beacon_to_delay_queue(wait=self.ttl))
+
+    async def autokill(self, ttl):
+        """
+        AutoKill task, sleeps as long as beacons are received, and exits the
+        process otherwise
+
+        This task captures cancel events (cancel is called from the beacon handler)
+        and keeps sleeping in that case, otherwise exits the process because that
+        means we didn't receive any beacons (AMQP connection is stalled)
+        """
+        loop = asyncio.get_event_loop()
+
+        while True:
+            try:
+                asleep = ttl * 3
+                logger.debug(f'autokill: sleeping for {asleep} seconds')
+                await asyncio.sleep(asleep)
+            except asyncio.CancelledError:
+                logger.debug(f'autokill: received cancel, beacon was received')
+                continue
+            except Exception as err:
+                logger.debug(f'autokill: unknown exception {err}')
+                continue
+            else:
+                logger.debug(f'autokill: No beacons received')
+                break
+
+        # No beacons received: set the autokill event, and schedule a call
+        # to os._exit a bit later so that unit tests can wait on autokill_event
+
+        logger.error(f'Exiting worker because of no beacon activity')
+
+        self.autokill_event.set()
+        loop.call_later(2, os._exit, 0)
+
+    async def publish_beacon_to_delay_queue(self, wait=0):
+        # Publish to beacon delay queue
+        await asyncio.sleep(wait)
+        try:
+            beacon_payload = json.dumps({'worker_beacon_uuid': self.worker_beacon_uuid})
+            await self.channel.publish(
+                beacon_payload,
+                exchange_name='beacon',
+                routing_key=self.beacon_delay_queue_name,
+                properties={
+                    'delivery_mode': 2,
+                }
+            )
+        except aioamqp.exceptions.ChannelClosed:
+            logger.debug(f'Beacon publish: channel is closed !')
+        else:
+            logger.debug(f'Beacon published: {beacon_payload}')
+
+    async def handle_beacon(self, channel, body, envelope, properties):
+        logger.debug(f'handle_beacon {body} {channel}')
+
+        if self.autokill_handler:
+            # ACK beacon queue
+            await self.channel.basic_client_ack(
+                delivery_tag=envelope.delivery_tag,
+            )
+            # Cancel previous autokill
+            self.autokill_handler.cancel()
+
+        # Schedule sending of beacon
+        if not self._stopped:
+            await self.publish_beacon_to_delay_queue(channel, wait=self.ttl)
+
+    def stop(self):
+        self._stopped = True
 
 
 async def connect(**kwargs):
@@ -241,9 +263,4 @@ async def connect(**kwargs):
         **kwargs
     )
     channel = await protocol.channel()
-
-    # Setup beacon liveness queues
-    await setup_beacon_queues(
-        channel, ttl=amqp_settings.get('beaconttl', 30))
-
     return channel, transport, protocol

--- a/guillotina_amqp/tests/test_amqp.py
+++ b/guillotina_amqp/tests/test_amqp.py
@@ -1,3 +1,4 @@
+from guillotina_amqp.amqp import get_beaconsmgr_for_connection
 from guillotina_amqp.state import TaskState
 from guillotina_amqp.utils import add_task
 from guillotina_amqp.utils import cancel_task
@@ -186,9 +187,6 @@ async def test_worker_retries_should_not_exceed_the_limit(dummy_request,
 async def test_worker_beacons_process_exit(dummy_request,
                                            amqp_worker,
                                            amqp_channel):
-    from guillotina_amqp.amqp import autokill_event
-    global autokill_event
-
     aiotask_context.set('request', dummy_request)
 
     # Give the worker some job and sleep
@@ -196,12 +194,15 @@ async def test_worker_beacons_process_exit(dummy_request,
     await cancel_task(ts.task_id)
     await asyncio.sleep(4)
 
+    # Get the beacons manager
+    mgr = await get_beaconsmgr_for_connection()
+
     # Stop the worker, which will disconnect from AMQP, preventing beacons from
     # being sent.
     await amqp_worker.stop()
 
     # Wait to see that the autokill event was set, meaning that we received
     # no beacons as expected and that the process will exit
-    await autokill_event.wait()
+    await mgr.autokill_event.wait()
 
     aiotask_context.set('request', None)


### PR DESCRIPTION
Remove the beacons globals in amqp.py and move everything to the
BeaconsManager class. A BeaconsManager is created for every connection
in get_connection().