### PR TITLE
Prevents amqp_worker fixture depend on rabbitmq_container fixture

### DIFF
--- a/guillotina_amqp/tests/fixtures.py
+++ b/guillotina_amqp/tests/fixtures.py
@@ -33,7 +33,7 @@ testing.configure_with(base_settings_configurator)
 
 
 @pytest.fixture('function')
-def amqp_worker(loop, rabbitmq_container):
+def amqp_worker(loop):
     amqp.logger.setLevel(10)
 
     # Create worker


### PR DESCRIPTION
Before, `amqp_worker` did not depend on any other fixture.

If someone used that fixture in their applications' tests, will now break unless they explicitly add the `[rabbitmq]` requirement for the package.