### PR TITLE
Add actual callable name in metric labels

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 3.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Include actual callable in metrics labels
 
 
 3.1.0 (2019-05-21)

--- a/guillotina_amqp/worker.py
+++ b/guillotina_amqp/worker.py
@@ -215,8 +215,17 @@ class Worker:
 
     @staticmethod
     def measure_job_duration(job, final_status):
+        dotted_name = job.data['func']
+        # Remove guillotina_amqp.utils part
+        dotted_name = dotted_name.split('.')[-1]
+
+        # Get actuall callable that is passed as the first parameter
+        # of func
+        real_func = job.data.get('args', [''])[0]
+        dotted_name += f'/{real_func}'
+
         labels = {
-            'dotted_name': job.data['func'],
+            'dotted_name': dotted_name,
             'final_status': final_status,
             'container_id': job.data.get('container_id'),
         }


### PR DESCRIPTION
Before this change, `dotted_name` label was always either `guillotina_amqp.utils._run_object_task` or `guillotina_amqp.utils._yield_object_task`, so we had no information about the actual callable being ran.

Now labels are:
```
{'dotted_name': '_yield_object_task/path.to.my.func', 'final_status': 'finished', 'container_id': 'mycontainer'}
```